### PR TITLE
Follow-ups to test-reporter Actions Summary support

### DIFF
--- a/__tests__/__outputs__/dart-json.md
+++ b/__tests__/__outputs__/dart-json.md
@@ -1,13 +1,13 @@
 ![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/dart-json.json|1:white_check_mark:|4:x:|1:warning:|4s|
+|fixtures/dart-json.json|1 :white_check_mark:|4 :x:|1 :warning:|4s|
 ## :x: <a id="user-content-r0" href="#r0">fixtures/dart-json.json</a>
 **6** tests were completed in **4s** with **1** passed, **4** failed and **1** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[test/main_test.dart](#r0s0)|1:white_check_mark:|3:x:||74ms|
-|[test/second_test.dart](#r0s1)||1:x:|1:warning:|51ms|
+|[test/main_test.dart](#r0s0)|1 :white_check_mark:|3 :x:||74ms|
+|[test/second_test.dart](#r0s1)||1 :x:|1 :warning:|51ms|
 ### :x: <a id="user-content-r0s0" href="#r0s0">test/main_test.dart</a>
 ```
 Test 1

--- a/__tests__/__outputs__/dotnet-trx.md
+++ b/__tests__/__outputs__/dotnet-trx.md
@@ -1,12 +1,12 @@
 ![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|DotnetTests.XUnitTests|5:white_check_mark:|5:x:|1:warning:|1s|
+|DotnetTests.XUnitTests|5 :white_check_mark:|5 :x:|1 :warning:|1s|
 ## :x: <a id="user-content-r0" href="#r0">DotnetTests.XUnitTests</a>
 **11** tests were completed in **1s** with **5** passed, **5** failed and **1** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[DotnetTests.XUnitTests.CalculatorTests](#r0s0)|5:white_check_mark:|5:x:|1:warning:|118ms|
+|[DotnetTests.XUnitTests.CalculatorTests](#r0s0)|5 :white_check_mark:|5 :x:|1 :warning:|118ms|
 ### :x: <a id="user-content-r0s0" href="#r0s0">DotnetTests.XUnitTests.CalculatorTests</a>
 ```
 :white_check_mark: Custom Name

--- a/__tests__/__outputs__/fluent-validation-test-results.md
+++ b/__tests__/__outputs__/fluent-validation-test-results.md
@@ -3,73 +3,73 @@
  
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|FluentValidation.Tests|803:white_check_mark:||1:warning:|4s|
+|FluentValidation.Tests|803 :white_check_mark:||1 :warning:|4s|
 ## :white_check_mark: <a id="user-content-r0" href="#r0">FluentValidation.Tests</a>
 **804** tests were completed in **4s** with **803** passed, **0** failed and **1** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[FluentValidation.Tests.AbstractValidatorTester](#r0s0)|35:white_check_mark:|||12ms|
-|[FluentValidation.Tests.AccessorCacheTests](#r0s1)|4:white_check_mark:||1:warning:|4ms|
-|[FluentValidation.Tests.AssemblyScannerTester](#r0s2)|2:white_check_mark:|||2ms|
-|[FluentValidation.Tests.CascadingFailuresTester](#r0s3)|38:white_check_mark:|||23ms|
-|[FluentValidation.Tests.ChainedValidationTester](#r0s4)|13:white_check_mark:|||6ms|
-|[FluentValidation.Tests.ChainingValidatorsTester](#r0s5)|3:white_check_mark:|||1ms|
-|[FluentValidation.Tests.ChildRulesTests](#r0s6)|2:white_check_mark:|||7ms|
-|[FluentValidation.Tests.CollectionValidatorWithParentTests](#r0s7)|16:white_check_mark:|||13ms|
-|[FluentValidation.Tests.ComplexValidationTester](#r0s8)|17:white_check_mark:|||26ms|
-|[FluentValidation.Tests.ConditionTests](#r0s9)|18:white_check_mark:|||9ms|
-|[FluentValidation.Tests.CreditCardValidatorTests](#r0s10)|2:white_check_mark:|||2ms|
-|[FluentValidation.Tests.CustomFailureActionTester](#r0s11)|3:white_check_mark:|||1ms|
-|[FluentValidation.Tests.CustomMessageFormatTester](#r0s12)|6:white_check_mark:|||3ms|
-|[FluentValidation.Tests.CustomValidatorTester](#r0s13)|10:white_check_mark:|||6ms|
-|[FluentValidation.Tests.DefaultValidatorExtensionTester](#r0s14)|30:white_check_mark:|||38ms|
-|[FluentValidation.Tests.EmailValidatorTests](#r0s15)|36:white_check_mark:|||18ms|
-|[FluentValidation.Tests.EmptyTester](#r0s16)|9:white_check_mark:|||5ms|
-|[FluentValidation.Tests.EnumValidatorTests](#r0s17)|12:white_check_mark:|||24ms|
-|[FluentValidation.Tests.EqualValidatorTests](#r0s18)|10:white_check_mark:|||3ms|
-|[FluentValidation.Tests.ExactLengthValidatorTester](#r0s19)|6:white_check_mark:|||2ms|
-|[FluentValidation.Tests.ExclusiveBetweenValidatorTests](#r0s20)|19:white_check_mark:|||6ms|
-|[FluentValidation.Tests.ExtensionTester](#r0s21)|4:white_check_mark:|||1ms|
-|[FluentValidation.Tests.ForEachRuleTests](#r0s22)|34:white_check_mark:|||47ms|
-|[FluentValidation.Tests.GreaterThanOrEqualToValidatorTester](#r0s23)|14:white_check_mark:|||5ms|
-|[FluentValidation.Tests.GreaterThanValidatorTester](#r0s24)|13:white_check_mark:|||4ms|
-|[FluentValidation.Tests.InclusiveBetweenValidatorTests](#r0s25)|18:white_check_mark:|||4ms|
-|[FluentValidation.Tests.InheritanceValidatorTest](#r0s26)|11:white_check_mark:|||18ms|
-|[FluentValidation.Tests.InlineValidatorTester](#r0s27)|1:white_check_mark:|||2ms|
-|[FluentValidation.Tests.LanguageManagerTests](#r0s28)|21:white_check_mark:|||28ms|
-|[FluentValidation.Tests.LengthValidatorTests](#r0s29)|16:white_check_mark:|||17ms|
-|[FluentValidation.Tests.LessThanOrEqualToValidatorTester](#r0s30)|13:white_check_mark:|||4ms|
-|[FluentValidation.Tests.LessThanValidatorTester](#r0s31)|16:white_check_mark:|||6ms|
-|[FluentValidation.Tests.LocalisedMessagesTester](#r0s32)|6:white_check_mark:|||3ms|
-|[FluentValidation.Tests.LocalisedNameTester](#r0s33)|2:white_check_mark:|||1ms|
-|[FluentValidation.Tests.MemberAccessorTests](#r0s34)|9:white_check_mark:|||5ms|
-|[FluentValidation.Tests.MessageFormatterTests](#r0s35)|10:white_check_mark:|||2ms|
-|[FluentValidation.Tests.ModelLevelValidatorTests](#r0s36)|2:white_check_mark:|||1ms|
-|[FluentValidation.Tests.NameResolutionPluggabilityTester](#r0s37)|3:white_check_mark:|||2ms|
-|[FluentValidation.Tests.NotEmptyTester](#r0s38)|10:white_check_mark:|||7ms|
-|[FluentValidation.Tests.NotEqualValidatorTests](#r0s39)|11:white_check_mark:|||7ms|
-|[FluentValidation.Tests.NotNullTester](#r0s40)|5:white_check_mark:|||1ms|
-|[FluentValidation.Tests.NullTester](#r0s41)|5:white_check_mark:|||2ms|
-|[FluentValidation.Tests.OnFailureTests](#r0s42)|10:white_check_mark:|||8ms|
-|[FluentValidation.Tests.PredicateValidatorTester](#r0s43)|5:white_check_mark:|||2ms|
-|[FluentValidation.Tests.PropertyChainTests](#r0s44)|7:white_check_mark:|||1ms|
-|[FluentValidation.Tests.RegularExpressionValidatorTests](#r0s45)|15:white_check_mark:|||6ms|
-|[FluentValidation.Tests.RuleBuilderTests](#r0s46)|29:white_check_mark:|||96ms|
-|[FluentValidation.Tests.RuleDependencyTests](#r0s47)|14:white_check_mark:|||3s|
-|[FluentValidation.Tests.RulesetTests](#r0s48)|21:white_check_mark:|||14ms|
-|[FluentValidation.Tests.ScalePrecisionValidatorTests](#r0s49)|6:white_check_mark:|||4ms|
-|[FluentValidation.Tests.SharedConditionTests](#r0s50)|42:white_check_mark:|||42ms|
-|[FluentValidation.Tests.StandalonePropertyValidationTester](#r0s51)|1:white_check_mark:|||0ms|
-|[FluentValidation.Tests.StringEnumValidatorTests](#r0s52)|10:white_check_mark:|||5ms|
-|[FluentValidation.Tests.TrackingCollectionTests](#r0s53)|3:white_check_mark:|||2ms|
-|[FluentValidation.Tests.TransformTests](#r0s54)|4:white_check_mark:|||3ms|
-|[FluentValidation.Tests.UserSeverityTester](#r0s55)|7:white_check_mark:|||3ms|
-|[FluentValidation.Tests.UserStateTester](#r0s56)|4:white_check_mark:|||3ms|
-|[FluentValidation.Tests.ValidateAndThrowTester](#r0s57)|14:white_check_mark:|||25ms|
-|[FluentValidation.Tests.ValidationResultTests](#r0s58)|8:white_check_mark:|||8ms|
-|[FluentValidation.Tests.ValidatorDescriptorTester](#r0s59)|5:white_check_mark:|||1ms|
-|[FluentValidation.Tests.ValidatorSelectorTests](#r0s60)|10:white_check_mark:|||9ms|
-|[FluentValidation.Tests.ValidatorTesterTester](#r0s61)|73:white_check_mark:|||74ms|
+|[FluentValidation.Tests.AbstractValidatorTester](#r0s0)|35 :white_check_mark:|||12ms|
+|[FluentValidation.Tests.AccessorCacheTests](#r0s1)|4 :white_check_mark:||1 :warning:|4ms|
+|[FluentValidation.Tests.AssemblyScannerTester](#r0s2)|2 :white_check_mark:|||2ms|
+|[FluentValidation.Tests.CascadingFailuresTester](#r0s3)|38 :white_check_mark:|||23ms|
+|[FluentValidation.Tests.ChainedValidationTester](#r0s4)|13 :white_check_mark:|||6ms|
+|[FluentValidation.Tests.ChainingValidatorsTester](#r0s5)|3 :white_check_mark:|||1ms|
+|[FluentValidation.Tests.ChildRulesTests](#r0s6)|2 :white_check_mark:|||7ms|
+|[FluentValidation.Tests.CollectionValidatorWithParentTests](#r0s7)|16 :white_check_mark:|||13ms|
+|[FluentValidation.Tests.ComplexValidationTester](#r0s8)|17 :white_check_mark:|||26ms|
+|[FluentValidation.Tests.ConditionTests](#r0s9)|18 :white_check_mark:|||9ms|
+|[FluentValidation.Tests.CreditCardValidatorTests](#r0s10)|2 :white_check_mark:|||2ms|
+|[FluentValidation.Tests.CustomFailureActionTester](#r0s11)|3 :white_check_mark:|||1ms|
+|[FluentValidation.Tests.CustomMessageFormatTester](#r0s12)|6 :white_check_mark:|||3ms|
+|[FluentValidation.Tests.CustomValidatorTester](#r0s13)|10 :white_check_mark:|||6ms|
+|[FluentValidation.Tests.DefaultValidatorExtensionTester](#r0s14)|30 :white_check_mark:|||38ms|
+|[FluentValidation.Tests.EmailValidatorTests](#r0s15)|36 :white_check_mark:|||18ms|
+|[FluentValidation.Tests.EmptyTester](#r0s16)|9 :white_check_mark:|||5ms|
+|[FluentValidation.Tests.EnumValidatorTests](#r0s17)|12 :white_check_mark:|||24ms|
+|[FluentValidation.Tests.EqualValidatorTests](#r0s18)|10 :white_check_mark:|||3ms|
+|[FluentValidation.Tests.ExactLengthValidatorTester](#r0s19)|6 :white_check_mark:|||2ms|
+|[FluentValidation.Tests.ExclusiveBetweenValidatorTests](#r0s20)|19 :white_check_mark:|||6ms|
+|[FluentValidation.Tests.ExtensionTester](#r0s21)|4 :white_check_mark:|||1ms|
+|[FluentValidation.Tests.ForEachRuleTests](#r0s22)|34 :white_check_mark:|||47ms|
+|[FluentValidation.Tests.GreaterThanOrEqualToValidatorTester](#r0s23)|14 :white_check_mark:|||5ms|
+|[FluentValidation.Tests.GreaterThanValidatorTester](#r0s24)|13 :white_check_mark:|||4ms|
+|[FluentValidation.Tests.InclusiveBetweenValidatorTests](#r0s25)|18 :white_check_mark:|||4ms|
+|[FluentValidation.Tests.InheritanceValidatorTest](#r0s26)|11 :white_check_mark:|||18ms|
+|[FluentValidation.Tests.InlineValidatorTester](#r0s27)|1 :white_check_mark:|||2ms|
+|[FluentValidation.Tests.LanguageManagerTests](#r0s28)|21 :white_check_mark:|||28ms|
+|[FluentValidation.Tests.LengthValidatorTests](#r0s29)|16 :white_check_mark:|||17ms|
+|[FluentValidation.Tests.LessThanOrEqualToValidatorTester](#r0s30)|13 :white_check_mark:|||4ms|
+|[FluentValidation.Tests.LessThanValidatorTester](#r0s31)|16 :white_check_mark:|||6ms|
+|[FluentValidation.Tests.LocalisedMessagesTester](#r0s32)|6 :white_check_mark:|||3ms|
+|[FluentValidation.Tests.LocalisedNameTester](#r0s33)|2 :white_check_mark:|||1ms|
+|[FluentValidation.Tests.MemberAccessorTests](#r0s34)|9 :white_check_mark:|||5ms|
+|[FluentValidation.Tests.MessageFormatterTests](#r0s35)|10 :white_check_mark:|||2ms|
+|[FluentValidation.Tests.ModelLevelValidatorTests](#r0s36)|2 :white_check_mark:|||1ms|
+|[FluentValidation.Tests.NameResolutionPluggabilityTester](#r0s37)|3 :white_check_mark:|||2ms|
+|[FluentValidation.Tests.NotEmptyTester](#r0s38)|10 :white_check_mark:|||7ms|
+|[FluentValidation.Tests.NotEqualValidatorTests](#r0s39)|11 :white_check_mark:|||7ms|
+|[FluentValidation.Tests.NotNullTester](#r0s40)|5 :white_check_mark:|||1ms|
+|[FluentValidation.Tests.NullTester](#r0s41)|5 :white_check_mark:|||2ms|
+|[FluentValidation.Tests.OnFailureTests](#r0s42)|10 :white_check_mark:|||8ms|
+|[FluentValidation.Tests.PredicateValidatorTester](#r0s43)|5 :white_check_mark:|||2ms|
+|[FluentValidation.Tests.PropertyChainTests](#r0s44)|7 :white_check_mark:|||1ms|
+|[FluentValidation.Tests.RegularExpressionValidatorTests](#r0s45)|15 :white_check_mark:|||6ms|
+|[FluentValidation.Tests.RuleBuilderTests](#r0s46)|29 :white_check_mark:|||96ms|
+|[FluentValidation.Tests.RuleDependencyTests](#r0s47)|14 :white_check_mark:|||3s|
+|[FluentValidation.Tests.RulesetTests](#r0s48)|21 :white_check_mark:|||14ms|
+|[FluentValidation.Tests.ScalePrecisionValidatorTests](#r0s49)|6 :white_check_mark:|||4ms|
+|[FluentValidation.Tests.SharedConditionTests](#r0s50)|42 :white_check_mark:|||42ms|
+|[FluentValidation.Tests.StandalonePropertyValidationTester](#r0s51)|1 :white_check_mark:|||0ms|
+|[FluentValidation.Tests.StringEnumValidatorTests](#r0s52)|10 :white_check_mark:|||5ms|
+|[FluentValidation.Tests.TrackingCollectionTests](#r0s53)|3 :white_check_mark:|||2ms|
+|[FluentValidation.Tests.TransformTests](#r0s54)|4 :white_check_mark:|||3ms|
+|[FluentValidation.Tests.UserSeverityTester](#r0s55)|7 :white_check_mark:|||3ms|
+|[FluentValidation.Tests.UserStateTester](#r0s56)|4 :white_check_mark:|||3ms|
+|[FluentValidation.Tests.ValidateAndThrowTester](#r0s57)|14 :white_check_mark:|||25ms|
+|[FluentValidation.Tests.ValidationResultTests](#r0s58)|8 :white_check_mark:|||8ms|
+|[FluentValidation.Tests.ValidatorDescriptorTester](#r0s59)|5 :white_check_mark:|||1ms|
+|[FluentValidation.Tests.ValidatorSelectorTests](#r0s60)|10 :white_check_mark:|||9ms|
+|[FluentValidation.Tests.ValidatorTesterTester](#r0s61)|73 :white_check_mark:|||74ms|
 ### :white_check_mark: <a id="user-content-r0s0" href="#r0s0">FluentValidation.Tests.AbstractValidatorTester</a>
 ```
 :white_check_mark: Can_replace_default_errorcode_resolver

--- a/__tests__/__outputs__/jest-junit.md
+++ b/__tests__/__outputs__/jest-junit.md
@@ -1,13 +1,13 @@
 ![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/jest-junit.xml|1:white_check_mark:|4:x:|1:warning:|1s|
+|fixtures/jest-junit.xml|1 :white_check_mark:|4 :x:|1 :warning:|1s|
 ## :x: <a id="user-content-r0" href="#r0">fixtures/jest-junit.xml</a>
 **6** tests were completed in **1s** with **1** passed, **4** failed and **1** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[__tests__\main.test.js](#r0s0)|1:white_check_mark:|3:x:||486ms|
-|[__tests__\second.test.js](#r0s1)||1:x:|1:warning:|82ms|
+|[__tests__\main.test.js](#r0s0)|1 :white_check_mark:|3 :x:||486ms|
+|[__tests__\second.test.js](#r0s1)||1 :x:|1 :warning:|82ms|
 ### :x: <a id="user-content-r0s0" href="#r0s0">__tests__\main.test.js</a>
 ```
 Test 1

--- a/__tests__/__outputs__/jest-react-component-test-results.md
+++ b/__tests__/__outputs__/jest-react-component-test-results.md
@@ -3,12 +3,12 @@
  
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/external/jest/jest-react-component-test-results.xml|1:white_check_mark:|||1000ms|
+|fixtures/external/jest/jest-react-component-test-results.xml|1 :white_check_mark:|||1000ms|
 ## :white_check_mark: <a id="user-content-r0" href="#r0">fixtures/external/jest/jest-react-component-test-results.xml</a>
 **1** tests were completed in **1000ms** with **1** passed, **0** failed and **0** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[\<Component /\>](#r0s0)|1:white_check_mark:|||798ms|
+|[\<Component /\>](#r0s0)|1 :white_check_mark:|||798ms|
 ### :white_check_mark: <a id="user-content-r0s0" href="#r0s0">\<Component /\></a>
 ```
 :white_check_mark: <Component /> should render properly

--- a/__tests__/__outputs__/jest-test-results.md
+++ b/__tests__/__outputs__/jest-test-results.md
@@ -1,411 +1,411 @@
 ![Tests failed](https://img.shields.io/badge/tests-4207%20passed%2C%202%20failed%2C%2030%20skipped-critical)
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/external/jest/jest-test-results.xml|4207:white_check_mark:|2:x:|30:warning:|166s|
+|fixtures/external/jest/jest-test-results.xml|4207 :white_check_mark:|2 :x:|30 :warning:|166s|
 ## :x: <a id="user-content-r0" href="#r0">fixtures/external/jest/jest-test-results.xml</a>
 **4239** tests were completed in **166s** with **4207** passed, **2** failed and **30** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[e2e/__tests__/asyncAndCallback.test.ts](#r0s0)|1:white_check_mark:|||746ms|
-|[e2e/__tests__/asyncRegenerator.test.ts](#r0s1)|1:white_check_mark:|||4s|
-|[e2e/__tests__/autoClearMocks.test.ts](#r0s2)|2:white_check_mark:|||2s|
-|[e2e/__tests__/autoResetMocks.test.ts](#r0s3)|2:white_check_mark:|||2s|
-|[e2e/__tests__/autoRestoreMocks.test.ts](#r0s4)|2:white_check_mark:|||2s|
-|[e2e/__tests__/babelPluginJestHoist.test.ts](#r0s5)|1:white_check_mark:|||6s|
-|[e2e/__tests__/badSourceMap.test.ts](#r0s6)|1:white_check_mark:|||858ms|
-|[e2e/__tests__/beforeAllFiltered.ts](#r0s7)|1:white_check_mark:|||958ms|
-|[e2e/__tests__/beforeEachQueue.ts](#r0s8)|1:white_check_mark:||1:warning:|55ms|
-|[e2e/__tests__/callDoneTwice.test.ts](#r0s9)|1:white_check_mark:|||882ms|
-|[e2e/__tests__/chaiAssertionLibrary.ts](#r0s10)|1:white_check_mark:|||2s|
-|[e2e/__tests__/circularInequality.test.ts](#r0s11)|1:white_check_mark:|||1s|
-|[e2e/__tests__/circusConcurrentEach.test.ts](#r0s12)|2:white_check_mark:|||2s|
-|[e2e/__tests__/circusDeclarationErrors.test.ts](#r0s13)|1:white_check_mark:|||869ms|
-|[e2e/__tests__/clearCache.test.ts](#r0s14)|2:white_check_mark:|||1s|
-|[e2e/__tests__/cliHandlesExactFilenames.test.ts](#r0s15)|2:white_check_mark:|||1s|
-|[e2e/__tests__/compareDomNodes.test.ts](#r0s16)|1:white_check_mark:|||1s|
-|[e2e/__tests__/config.test.ts](#r0s17)|6:white_check_mark:|||4s|
-|[e2e/__tests__/console.test.ts](#r0s18)|7:white_check_mark:|||8s|
-|[e2e/__tests__/consoleAfterTeardown.test.ts](#r0s19)|1:white_check_mark:|||1s|
-|[e2e/__tests__/consoleLogOutputWhenRunInBand.test.ts](#r0s20)|1:white_check_mark:|||793ms|
-|[e2e/__tests__/coverageHandlebars.test.ts](#r0s21)|1:white_check_mark:|||2s|
-|[e2e/__tests__/coverageRemapping.test.ts](#r0s22)|1:white_check_mark:|||13s|
-|[e2e/__tests__/coverageReport.test.ts](#r0s23)|12:white_check_mark:|||22s|
-|[e2e/__tests__/coverageThreshold.test.ts](#r0s24)|5:white_check_mark:|||5s|
-|[e2e/__tests__/coverageTransformInstrumented.test.ts](#r0s25)|1:white_check_mark:|||5s|
-|[e2e/__tests__/coverageWithoutTransform.test.ts](#r0s26)|1:white_check_mark:|||1s|
-|[e2e/__tests__/createProcessObject.test.ts](#r0s27)|1:white_check_mark:|||908ms|
-|[e2e/__tests__/customInlineSnapshotMatchers.test.ts](#r0s28)|1:white_check_mark:|||2s|
-|[e2e/__tests__/customMatcherStackTrace.test.ts](#r0s29)|2:white_check_mark:|||2s|
-|[e2e/__tests__/customReporters.test.ts](#r0s30)|9:white_check_mark:|||7s|
-|[e2e/__tests__/customResolver.test.ts](#r0s31)|1:white_check_mark:|||826ms|
-|[e2e/__tests__/customTestSequencers.test.ts](#r0s32)|3:white_check_mark:|||3s|
-|[e2e/__tests__/debug.test.ts](#r0s33)|1:white_check_mark:|||899ms|
-|[e2e/__tests__/declarationErrors.test.ts](#r0s34)|3:white_check_mark:|||2s|
-|[e2e/__tests__/dependencyClash.test.ts](#r0s35)|1:white_check_mark:|||833ms|
-|[e2e/__tests__/detectOpenHandles.ts](#r0s36)|8:white_check_mark:|||8s|
-|[e2e/__tests__/domDiffing.test.ts](#r0s37)|1:white_check_mark:|||1s|
-|[e2e/__tests__/doneInHooks.test.ts](#r0s38)|1:white_check_mark:|||855ms|
-|[e2e/__tests__/dynamicRequireDependencies.ts](#r0s39)|1:white_check_mark:|||847ms|
-|[e2e/__tests__/each.test.ts](#r0s40)|7:white_check_mark:|||5s|
-|[e2e/__tests__/emptyDescribeWithHooks.test.ts](#r0s41)|4:white_check_mark:|||3s|
-|[e2e/__tests__/emptySuiteError.test.ts](#r0s42)|1:white_check_mark:|||885ms|
-|[e2e/__tests__/env.test.ts](#r0s43)|6:white_check_mark:|||5s|
-|[e2e/__tests__/environmentAfterTeardown.test.ts](#r0s44)|1:white_check_mark:|||892ms|
-|[e2e/__tests__/errorOnDeprecated.test.ts](#r0s45)|1:white_check_mark:||24:warning:|56ms|
-|[e2e/__tests__/esmConfigFile.test.ts](#r0s46)|3:white_check_mark:|||526ms|
-|[e2e/__tests__/executeTestsOnceInMpr.ts](#r0s47)|1:white_check_mark:|||976ms|
-|[e2e/__tests__/existentRoots.test.ts](#r0s48)|4:white_check_mark:|||627ms|
-|[e2e/__tests__/expectAsyncMatcher.test.ts](#r0s49)|2:white_check_mark:|||3s|
-|[e2e/__tests__/expectInVm.test.ts](#r0s50)|1:white_check_mark:|||2s|
-|[e2e/__tests__/extraGlobals.test.ts](#r0s51)|1:white_check_mark:|||1s|
-|[e2e/__tests__/failureDetailsProperty.test.ts](#r0s52)|1:white_check_mark:|||907ms|
-|[e2e/__tests__/failures.test.ts](#r0s53)|7:white_check_mark:|||10s|
-|[e2e/__tests__/fakePromises.test.ts](#r0s54)|2:white_check_mark:|||2s|
-|[e2e/__tests__/fatalWorkerError.test.ts](#r0s55)|1:white_check_mark:|||3s|
-|[e2e/__tests__/filter.test.ts](#r0s56)|7:white_check_mark:|||5s|
-|[e2e/__tests__/findRelatedFiles.test.ts](#r0s57)|5:white_check_mark:|||6s|
-|[e2e/__tests__/focusedTests.test.ts](#r0s58)|1:white_check_mark:|||888ms|
-|[e2e/__tests__/forceExit.test.ts](#r0s59)|1:white_check_mark:|||2s|
-|[e2e/__tests__/generatorMock.test.ts](#r0s60)|1:white_check_mark:|||1s|
-|[e2e/__tests__/global-mutation.test.ts](#r0s61)|1:white_check_mark:|||40ms|
-|[e2e/__tests__/global.test.ts](#r0s62)|1:white_check_mark:|||31ms|
-|[e2e/__tests__/globals.test.ts](#r0s63)|10:white_check_mark:|||8s|
-|[e2e/__tests__/globalSetup.test.ts](#r0s64)|10:white_check_mark:|||14s|
-|[e2e/__tests__/globalTeardown.test.ts](#r0s65)|7:white_check_mark:|||12s|
-|[e2e/__tests__/hasteMapMockChanged.test.ts](#r0s66)|1:white_check_mark:|||379ms|
-|[e2e/__tests__/hasteMapSha1.test.ts](#r0s67)|1:white_check_mark:|||298ms|
-|[e2e/__tests__/hasteMapSize.test.ts](#r0s68)|2:white_check_mark:|||397ms|
-|[e2e/__tests__/importedGlobals.test.ts](#r0s69)|1:white_check_mark:|||1s|
-|[e2e/__tests__/injectGlobals.test.ts](#r0s70)|2:white_check_mark:|||2s|
-|[e2e/__tests__/jasmineAsync.test.ts](#r0s71)|15:white_check_mark:|||28s|
-|[e2e/__tests__/jasmineAsyncWithPendingDuringTest.ts](#r0s72)|1:white_check_mark:||1:warning:|72ms|
-|[e2e/__tests__/jest.config.js.test.ts](#r0s73)|3:white_check_mark:|||2s|
-|[e2e/__tests__/jest.config.ts.test.ts](#r0s74)|5:white_check_mark:|||14s|
-|[e2e/__tests__/jestChangedFiles.test.ts](#r0s75)|9:white_check_mark:|1:x:||9s|
-|[e2e/__tests__/jestEnvironmentJsdom.test.ts](#r0s76)|1:white_check_mark:|||2s|
-|[e2e/__tests__/jestRequireActual.test.ts](#r0s77)|1:white_check_mark:|||2s|
-|[e2e/__tests__/jestRequireMock.test.ts](#r0s78)|1:white_check_mark:|||2s|
-|[e2e/__tests__/json.test.ts](#r0s79)|2:white_check_mark:|||29ms|
-|[e2e/__tests__/jsonReporter.test.ts](#r0s80)|2:white_check_mark:|||2s|
-|[e2e/__tests__/lifecycles.ts](#r0s81)|1:white_check_mark:|||861ms|
-|[e2e/__tests__/listTests.test.ts](#r0s82)|2:white_check_mark:|||945ms|
-|[e2e/__tests__/locationInResults.test.ts](#r0s83)|2:white_check_mark:|||2s|
-|[e2e/__tests__/logHeapUsage.test.ts](#r0s84)|1:white_check_mark:|||884ms|
-|[e2e/__tests__/mockNames.test.ts](#r0s85)|8:white_check_mark:|||7s|
-|[e2e/__tests__/modernFakeTimers.test.ts](#r0s86)|2:white_check_mark:|||2s|
-|[e2e/__tests__/moduleNameMapper.test.ts](#r0s87)|5:white_check_mark:|||5s|
-|[e2e/__tests__/moduleParentNullInTest.ts](#r0s88)|1:white_check_mark:|||886ms|
-|[e2e/__tests__/multiProjectRunner.test.ts](#r0s89)|14:white_check_mark:|||16s|
-|[e2e/__tests__/nativeAsyncMock.test.ts](#r0s90)|1:white_check_mark:|||55ms|
-|[e2e/__tests__/nativeEsm.test.ts](#r0s91)|2:white_check_mark:||1:warning:|905ms|
-|[e2e/__tests__/nativeEsmTypescript.test.ts](#r0s92)|1:white_check_mark:|||956ms|
-|[e2e/__tests__/nestedEventLoop.test.ts](#r0s93)|1:white_check_mark:|||1s|
-|[e2e/__tests__/nestedTestDefinitions.test.ts](#r0s94)|4:white_check_mark:|||5s|
-|[e2e/__tests__/nodePath.test.ts](#r0s95)|1:white_check_mark:|||866ms|
-|[e2e/__tests__/noTestFound.test.ts](#r0s96)|2:white_check_mark:|||1s|
-|[e2e/__tests__/noTestsFound.test.ts](#r0s97)|5:white_check_mark:|||3s|
-|[e2e/__tests__/onlyChanged.test.ts](#r0s98)|8:white_check_mark:|1:x:||22s|
-|[e2e/__tests__/onlyFailuresNonWatch.test.ts](#r0s99)|1:white_check_mark:|||3s|
-|[e2e/__tests__/overrideGlobals.test.ts](#r0s100)|2:white_check_mark:|||2s|
-|[e2e/__tests__/pnp.test.ts](#r0s101)|1:white_check_mark:|||3s|
-|[e2e/__tests__/presets.test.ts](#r0s102)|2:white_check_mark:|||2s|
-|[e2e/__tests__/processExit.test.ts](#r0s103)|1:white_check_mark:|||1s|
-|[e2e/__tests__/promiseReject.test.ts](#r0s104)|1:white_check_mark:|||967ms|
-|[e2e/__tests__/regexCharInPath.test.ts](#r0s105)|1:white_check_mark:|||962ms|
-|[e2e/__tests__/requireAfterTeardown.test.ts](#r0s106)|1:white_check_mark:|||921ms|
-|[e2e/__tests__/requireMain.test.ts](#r0s107)|1:white_check_mark:|||1s|
-|[e2e/__tests__/requireMainAfterCreateRequire.test.ts](#r0s108)|1:white_check_mark:|||966ms|
-|[e2e/__tests__/requireMainIsolateModules.test.ts](#r0s109)|1:white_check_mark:|||976ms|
-|[e2e/__tests__/requireMainResetModules.test.ts](#r0s110)|2:white_check_mark:|||2s|
-|[e2e/__tests__/requireV8Module.test.ts](#r0s111)|1:white_check_mark:|||30ms|
-|[e2e/__tests__/resetModules.test.ts](#r0s112)|1:white_check_mark:|||926ms|
-|[e2e/__tests__/resolve.test.ts](#r0s113)|1:white_check_mark:|||2s|
-|[e2e/__tests__/resolveGetPaths.test.ts](#r0s114)|1:white_check_mark:|||1s|
-|[e2e/__tests__/resolveNodeModule.test.ts](#r0s115)|1:white_check_mark:|||943ms|
-|[e2e/__tests__/resolveNoFileExtensions.test.ts](#r0s116)|2:white_check_mark:|||1s|
-|[e2e/__tests__/resolveWithPaths.test.ts](#r0s117)|1:white_check_mark:|||1s|
-|[e2e/__tests__/runProgrammatically.test.ts](#r0s118)|2:white_check_mark:|||575ms|
-|[e2e/__tests__/runTestsByPath.test.ts](#r0s119)|1:white_check_mark:|||2s|
-|[e2e/__tests__/runtimeInternalModuleRegistry.test.ts](#r0s120)|1:white_check_mark:|||1s|
-|[e2e/__tests__/selectProjects.test.ts](#r0s121)|18:white_check_mark:|||5s|
-|[e2e/__tests__/setImmediate.test.ts](#r0s122)|1:white_check_mark:|||904ms|
-|[e2e/__tests__/setupFilesAfterEnvConfig.test.ts](#r0s123)|2:white_check_mark:|||2s|
-|[e2e/__tests__/showConfig.test.ts](#r0s124)|1:white_check_mark:|||195ms|
-|[e2e/__tests__/skipBeforeAfterAll.test.ts](#r0s125)|1:white_check_mark:|||1s|
-|[e2e/__tests__/snapshot-unknown.test.ts](#r0s126)|1:white_check_mark:|||838ms|
-|[e2e/__tests__/snapshot.test.ts](#r0s127)|9:white_check_mark:|||14s|
-|[e2e/__tests__/snapshotMockFs.test.ts](#r0s128)|1:white_check_mark:|||883ms|
-|[e2e/__tests__/snapshotResolver.test.ts](#r0s129)|1:white_check_mark:|||823ms|
-|[e2e/__tests__/snapshotSerializers.test.ts](#r0s130)|2:white_check_mark:|||2s|
-|[e2e/__tests__/stackTrace.test.ts](#r0s131)|7:white_check_mark:|||5s|
-|[e2e/__tests__/stackTraceNoCaptureStackTrace.test.ts](#r0s132)|1:white_check_mark:|||899ms|
-|[e2e/__tests__/stackTraceSourceMaps.test.ts](#r0s133)|1:white_check_mark:|||2s|
-|[e2e/__tests__/stackTraceSourceMapsWithCoverage.test.ts](#r0s134)|1:white_check_mark:|||2s|
-|[e2e/__tests__/supportsDashedArgs.ts](#r0s135)|2:white_check_mark:|||968ms|
-|[e2e/__tests__/symbol.test.ts](#r0s136)|1:white_check_mark:|||49ms|
-|[e2e/__tests__/testEnvironment.test.ts](#r0s137)|1:white_check_mark:|||2s|
-|[e2e/__tests__/testEnvironmentAsync.test.ts](#r0s138)|1:white_check_mark:|||1s|
-|[e2e/__tests__/testEnvironmentCircus.test.ts](#r0s139)|1:white_check_mark:|||2s|
-|[e2e/__tests__/testEnvironmentCircusAsync.test.ts](#r0s140)|1:white_check_mark:|||2s|
-|[e2e/__tests__/testFailureExitCode.test.ts](#r0s141)|2:white_check_mark:|||4s|
-|[e2e/__tests__/testInRoot.test.ts](#r0s142)|1:white_check_mark:|||1s|
-|[e2e/__tests__/testNamePattern.test.ts](#r0s143)|1:white_check_mark:|||859ms|
-|[e2e/__tests__/testNamePatternSkipped.test.ts](#r0s144)|1:white_check_mark:|||991ms|
-|[e2e/__tests__/testPathPatternReporterMessage.test.ts](#r0s145)|1:white_check_mark:|||3s|
-|[e2e/__tests__/testResultsProcessor.test.ts](#r0s146)|1:white_check_mark:|||910ms|
-|[e2e/__tests__/testRetries.test.ts](#r0s147)|4:white_check_mark:|||3s|
-|[e2e/__tests__/testTodo.test.ts](#r0s148)|5:white_check_mark:|||4s|
-|[e2e/__tests__/timeouts.test.ts](#r0s149)|4:white_check_mark:|||4s|
-|[e2e/__tests__/timeoutsLegacy.test.ts](#r0s150)|1:white_check_mark:||3:warning:|71ms|
-|[e2e/__tests__/timerResetMocks.test.ts](#r0s151)|2:white_check_mark:|||2s|
-|[e2e/__tests__/timerUseRealTimers.test.ts](#r0s152)|1:white_check_mark:|||1s|
-|[e2e/__tests__/toMatchInlineSnapshot.test.ts](#r0s153)|12:white_check_mark:|||24s|
-|[e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts](#r0s154)|3:white_check_mark:|||5s|
-|[e2e/__tests__/toMatchSnapshot.test.ts](#r0s155)|9:white_check_mark:|||17s|
-|[e2e/__tests__/toMatchSnapshotWithRetries.test.ts](#r0s156)|2:white_check_mark:|||4s|
-|[e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts](#r0s157)|3:white_check_mark:|||4s|
-|[e2e/__tests__/toThrowErrorMatchingInlineSnapshot.test.ts](#r0s158)|4:white_check_mark:|||4s|
-|[e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts](#r0s159)|5:white_check_mark:|||4s|
-|[e2e/__tests__/transform.test.ts](#r0s160)|16:white_check_mark:|||27s|
-|[e2e/__tests__/transformLinkedModules.test.ts](#r0s161)|1:white_check_mark:|||783ms|
-|[e2e/__tests__/typescriptCoverage.test.ts](#r0s162)|1:white_check_mark:|||3s|
-|[e2e/__tests__/unexpectedToken.test.ts](#r0s163)|3:white_check_mark:|||3s|
-|[e2e/__tests__/useStderr.test.ts](#r0s164)|1:white_check_mark:|||1s|
-|[e2e/__tests__/v8Coverage.test.ts](#r0s165)|2:white_check_mark:|||2s|
-|[e2e/__tests__/verbose.test.ts](#r0s166)|1:white_check_mark:|||683ms|
-|[e2e/__tests__/version.test.ts](#r0s167)|1:white_check_mark:|||138ms|
-|[e2e/__tests__/watchModeNoAccess.test.ts](#r0s168)|1:white_check_mark:|||4s|
-|[e2e/__tests__/watchModeOnlyFailed.test.ts](#r0s169)|1:white_check_mark:|||1s|
-|[e2e/__tests__/watchModePatterns.test.ts](#r0s170)|2:white_check_mark:|||4s|
-|[e2e/__tests__/watchModeUpdateSnapshot.test.ts](#r0s171)|1:white_check_mark:|||1s|
-|[e2e/__tests__/workerForceExit.test.ts](#r0s172)|2:white_check_mark:|||5s|
-|[e2e/__tests__/wrongEnv.test.ts](#r0s173)|5:white_check_mark:|||4s|
-|[e2e/custom-test-sequencer/a.test.js](#r0s174)|1:white_check_mark:|||29ms|
-|[e2e/custom-test-sequencer/b.test.js](#r0s175)|1:white_check_mark:|||21ms|
-|[e2e/custom-test-sequencer/c.test.js](#r0s176)|1:white_check_mark:|||42ms|
-|[e2e/custom-test-sequencer/d.test.js](#r0s177)|1:white_check_mark:|||21ms|
-|[e2e/custom-test-sequencer/e.test.js](#r0s178)|1:white_check_mark:|||27ms|
-|[e2e/test-in-root/spec.js](#r0s179)|1:white_check_mark:|||19ms|
-|[e2e/test-in-root/test.js](#r0s180)|1:white_check_mark:|||37ms|
-|[e2e/timer-reset-mocks/after-reset-all-mocks/timerAndMock.test.js](#r0s181)|2:white_check_mark:|||30ms|
-|[e2e/timer-reset-mocks/with-reset-mocks/timerWithMock.test.js](#r0s182)|1:white_check_mark:|||34ms|
-|[e2e/v8-coverage/empty-sourcemap/test.ts](#r0s183)|1:white_check_mark:|||31ms|
-|[examples/angular/app.component.spec.ts](#r0s184)|3:white_check_mark:|||654ms|
-|[examples/angular/shared/data.service.spec.ts](#r0s185)|2:white_check_mark:|||431ms|
-|[examples/angular/shared/sub.service.spec.ts](#r0s186)|1:white_check_mark:|||109ms|
-|[examples/async/__tests__/user.test.js](#r0s187)|8:white_check_mark:|||96ms|
-|[examples/automatic-mocks/__tests__/automock.test.js](#r0s188)|2:white_check_mark:|||74ms|
-|[examples/automatic-mocks/__tests__/createMockFromModule.test.js](#r0s189)|2:white_check_mark:|||115ms|
-|[examples/automatic-mocks/__tests__/disableAutomocking.test.js](#r0s190)|1:white_check_mark:|||24ms|
-|[examples/enzyme/__tests__/CheckboxWithLabel-test.js](#r0s191)|1:white_check_mark:|||434ms|
-|[examples/getting-started/sum.test.js](#r0s192)|1:white_check_mark:|||78ms|
-|[examples/jquery/__tests__/display_user.test.js](#r0s193)|1:white_check_mark:|||196ms|
-|[examples/jquery/__tests__/fetch_current_user.test.js](#r0s194)|2:white_check_mark:|||196ms|
-|[examples/manual-mocks/__tests__/file_summarizer.test.js](#r0s195)|1:white_check_mark:|||87ms|
-|[examples/manual-mocks/__tests__/lodashMocking.test.js](#r0s196)|1:white_check_mark:|||109ms|
-|[examples/manual-mocks/__tests__/user.test.js](#r0s197)|1:white_check_mark:|||41ms|
-|[examples/manual-mocks/__tests__/userMocked.test.js](#r0s198)|1:white_check_mark:|||105ms|
-|[examples/module-mock/__tests__/full_mock.js](#r0s199)|1:white_check_mark:|||60ms|
-|[examples/module-mock/__tests__/mock_per_test.js](#r0s200)|2:white_check_mark:|||116ms|
-|[examples/module-mock/__tests__/partial_mock.js](#r0s201)|1:white_check_mark:|||215ms|
-|[examples/mongodb/__test__/db.test.js](#r0s202)|1:white_check_mark:|||236ms|
-|[examples/react-native/__tests__/intro.test.js](#r0s203)|4:white_check_mark:|||9s|
-|[examples/react-testing-library/__tests__/CheckboxWithLabel-test.js](#r0s204)|1:white_check_mark:|||469ms|
-|[examples/react/__tests__/CheckboxWithLabel-test.js](#r0s205)|1:white_check_mark:|||256ms|
-|[examples/snapshot/__tests__/clock.react.test.js](#r0s206)|1:white_check_mark:|||62ms|
-|[examples/snapshot/__tests__/link.react.test.js](#r0s207)|4:white_check_mark:|||181ms|
-|[examples/timer/__tests__/infinite_timer_game.test.js](#r0s208)|1:white_check_mark:|||94ms|
-|[examples/timer/__tests__/timer_game.test.js](#r0s209)|3:white_check_mark:|||74ms|
-|[examples/typescript/__tests__/calc.test.ts](#r0s210)|6:white_check_mark:|||276ms|
-|[examples/typescript/__tests__/CheckboxWithLabel-test.tsx](#r0s211)|1:white_check_mark:|||227ms|
-|[examples/typescript/__tests__/sub-test.ts](#r0s212)|1:white_check_mark:|||43ms|
-|[examples/typescript/__tests__/sum-test.ts](#r0s213)|2:white_check_mark:|||69ms|
-|[examples/typescript/__tests__/sum.test.js](#r0s214)|2:white_check_mark:|||100ms|
-|[packages/babel-jest/src/__tests__/index.ts](#r0s215)|6:white_check_mark:|||371ms|
-|[packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts](#r0s216)|4:white_check_mark:|||347ms|
-|[packages/diff-sequences/src/__tests__/index.property.test.ts](#r0s217)|7:white_check_mark:|||357ms|
-|[packages/diff-sequences/src/__tests__/index.test.ts](#r0s218)|48:white_check_mark:|||195ms|
-|[packages/expect/src/__tests__/assertionCounts.test.ts](#r0s219)|6:white_check_mark:|||60ms|
-|[packages/expect/src/__tests__/asymmetricMatchers.test.ts](#r0s220)|38:white_check_mark:|||207ms|
-|[packages/expect/src/__tests__/extend.test.ts](#r0s221)|10:white_check_mark:|||99ms|
-|[packages/expect/src/__tests__/isError.test.ts](#r0s222)|4:white_check_mark:|||43ms|
-|[packages/expect/src/__tests__/matchers-toContain.property.test.ts](#r0s223)|2:white_check_mark:|||236ms|
-|[packages/expect/src/__tests__/matchers-toContainEqual.property.test.ts](#r0s224)|2:white_check_mark:|||287ms|
-|[packages/expect/src/__tests__/matchers-toEqual.property.test.ts](#r0s225)|2:white_check_mark:|||1s|
-|[packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts](#r0s226)|3:white_check_mark:|||394ms|
-|[packages/expect/src/__tests__/matchers.test.js](#r0s227)|592:white_check_mark:|||862ms|
-|[packages/expect/src/__tests__/spyMatchers.test.ts](#r0s228)|248:white_check_mark:|||395ms|
-|[packages/expect/src/__tests__/stacktrace.test.ts](#r0s229)|3:white_check_mark:|||69ms|
-|[packages/expect/src/__tests__/symbolInObjects.test.ts](#r0s230)|3:white_check_mark:|||33ms|
-|[packages/expect/src/__tests__/toEqual-dom.test.ts](#r0s231)|12:white_check_mark:|||99ms|
-|[packages/expect/src/__tests__/toThrowMatchers.test.ts](#r0s232)|98:white_check_mark:|||257ms|
-|[packages/expect/src/__tests__/utils.test.ts](#r0s233)|41:white_check_mark:|||147ms|
-|[packages/jest-circus/src/__tests__/afterAll.test.ts](#r0s234)|6:white_check_mark:|||6s|
-|[packages/jest-circus/src/__tests__/baseTest.test.ts](#r0s235)|2:white_check_mark:|||3s|
-|[packages/jest-circus/src/__tests__/circusItTestError.test.ts](#r0s236)|8:white_check_mark:|||300ms|
-|[packages/jest-circus/src/__tests__/circusItTodoTestError.test.ts](#r0s237)|3:white_check_mark:|||81ms|
-|[packages/jest-circus/src/__tests__/hooks.test.ts](#r0s238)|3:white_check_mark:|||4s|
-|[packages/jest-circus/src/__tests__/hooksError.test.ts](#r0s239)|32:white_check_mark:|||127ms|
-|[packages/jest-cli/src/__tests__/cli/args.test.ts](#r0s240)|17:white_check_mark:|||345ms|
-|[packages/jest-cli/src/init/__tests__/init.test.js](#r0s241)|24:white_check_mark:|||119ms|
-|[packages/jest-cli/src/init/__tests__/modifyPackageJson.test.ts](#r0s242)|4:white_check_mark:|||30ms|
-|[packages/jest-config/src/__tests__/Defaults.test.ts](#r0s243)|1:white_check_mark:|||672ms|
-|[packages/jest-config/src/__tests__/getMaxWorkers.test.ts](#r0s244)|7:white_check_mark:|||67ms|
-|[packages/jest-config/src/__tests__/normalize.test.js](#r0s245)|118:white_check_mark:|||798ms|
-|[packages/jest-config/src/__tests__/readConfig.test.ts](#r0s246)|1:white_check_mark:|||76ms|
-|[packages/jest-config/src/__tests__/readConfigs.test.ts](#r0s247)|3:white_check_mark:|||135ms|
-|[packages/jest-config/src/__tests__/resolveConfigPath.test.ts](#r0s248)|10:white_check_mark:|||183ms|
-|[packages/jest-config/src/__tests__/setFromArgv.test.ts](#r0s249)|4:white_check_mark:|||53ms|
-|[packages/jest-config/src/__tests__/validatePattern.test.ts](#r0s250)|4:white_check_mark:|||52ms|
-|[packages/jest-console/src/__tests__/bufferedConsole.test.ts](#r0s251)|20:white_check_mark:|||171ms|
-|[packages/jest-console/src/__tests__/CustomConsole.test.ts](#r0s252)|23:white_check_mark:|||115ms|
-|[packages/jest-console/src/__tests__/getConsoleOutput.test.ts](#r0s253)|12:white_check_mark:|||56ms|
-|[packages/jest-core/src/__tests__/FailedTestsCache.test.js](#r0s254)|1:white_check_mark:|||25ms|
-|[packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js](#r0s255)|5:white_check_mark:|||61ms|
-|[packages/jest-core/src/__tests__/globals.test.ts](#r0s256)|1:white_check_mark:|||22ms|
-|[packages/jest-core/src/__tests__/runJest.test.js](#r0s257)|2:white_check_mark:|||261ms|
-|[packages/jest-core/src/__tests__/SearchSource.test.ts](#r0s258)|27:white_check_mark:|||3s|
-|[packages/jest-core/src/__tests__/SnapshotInteractiveMode.test.js](#r0s259)|13:white_check_mark:|||89ms|
-|[packages/jest-core/src/__tests__/TestScheduler.test.js](#r0s260)|8:white_check_mark:|||520ms|
-|[packages/jest-core/src/__tests__/testSchedulerHelper.test.js](#r0s261)|12:white_check_mark:|||48ms|
-|[packages/jest-core/src/__tests__/watch.test.js](#r0s262)|80:white_check_mark:|||7s|
-|[packages/jest-core/src/__tests__/watchFileChanges.test.ts](#r0s263)|1:white_check_mark:|||2s|
-|[packages/jest-core/src/__tests__/watchFilenamePatternMode.test.js](#r0s264)|2:white_check_mark:|||165ms|
-|[packages/jest-core/src/__tests__/watchTestNamePatternMode.test.js](#r0s265)|1:white_check_mark:|||246ms|
-|[packages/jest-core/src/lib/__tests__/isValidPath.test.ts](#r0s266)|3:white_check_mark:|||166ms|
-|[packages/jest-core/src/lib/__tests__/logDebugMessages.test.ts](#r0s267)|3:white_check_mark:|||48ms|
-|[packages/jest-create-cache-key-function/src/__tests__/index.test.ts](#r0s268)|1:white_check_mark:|||75ms|
-|[packages/jest-diff/src/__tests__/diff.test.ts](#r0s269)|107:white_check_mark:|||625ms|
-|[packages/jest-diff/src/__tests__/diffStringsRaw.test.ts](#r0s270)|2:white_check_mark:|||55ms|
-|[packages/jest-diff/src/__tests__/getAlignedDiffs.test.ts](#r0s271)|24:white_check_mark:|||72ms|
-|[packages/jest-diff/src/__tests__/joinAlignedDiffs.test.ts](#r0s272)|6:white_check_mark:|||44ms|
-|[packages/jest-docblock/src/__tests__/index.test.ts](#r0s273)|36:white_check_mark:|||177ms|
-|[packages/jest-each/src/__tests__/array.test.ts](#r0s274)|159:white_check_mark:|||192ms|
-|[packages/jest-each/src/__tests__/index.test.ts](#r0s275)|10:white_check_mark:|||44ms|
-|[packages/jest-each/src/__tests__/template.test.ts](#r0s276)|242:white_check_mark:|||483ms|
-|[packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts](#r0s277)|2:white_check_mark:|||783ms|
-|[packages/jest-environment-node/src/__tests__/node_environment.test.ts](#r0s278)|6:white_check_mark:|||184ms|
-|[packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts](#r0s279)|50:white_check_mark:|||302ms|
-|[packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts](#r0s280)|40:white_check_mark:|||317ms|
-|[packages/jest-get-type/src/__tests__/getType.test.ts](#r0s281)|14:white_check_mark:|||45ms|
-|[packages/jest-get-type/src/__tests__/isPrimitive.test.ts](#r0s282)|18:white_check_mark:|||36ms|
-|[packages/jest-globals/src/__tests__/index.ts](#r0s283)|1:white_check_mark:|||533ms|
-|[packages/jest-haste-map/src/__tests__/get_mock_name.test.js](#r0s284)|1:white_check_mark:|||22ms|
-|[packages/jest-haste-map/src/__tests__/includes_dotfiles.test.ts](#r0s285)|1:white_check_mark:|||337ms|
-|[packages/jest-haste-map/src/__tests__/index.test.js](#r0s286)|44:white_check_mark:|||1s|
-|[packages/jest-haste-map/src/__tests__/worker.test.js](#r0s287)|7:white_check_mark:|||100ms|
-|[packages/jest-haste-map/src/crawlers/__tests__/node.test.js](#r0s288)|10:white_check_mark:|||170ms|
-|[packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js](#r0s289)|8:white_check_mark:|||153ms|
-|[packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js](#r0s290)|15:white_check_mark:|||56ms|
-|[packages/jest-haste-map/src/lib/__tests__/fast_path.test.js](#r0s291)|5:white_check_mark:|||29ms|
-|[packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js](#r0s292)|1:white_check_mark:|||35ms|
-|[packages/jest-haste-map/src/lib/__tests__/isRegExpSupported.test.js](#r0s293)|2:white_check_mark:|||31ms|
-|[packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js](#r0s294)|2:white_check_mark:|||35ms|
-|[packages/jest-jasmine2/src/__tests__/concurrent.test.ts](#r0s295)|3:white_check_mark:|||24ms|
-|[packages/jest-jasmine2/src/__tests__/expectationResultFactory.test.ts](#r0s296)|7:white_check_mark:|||70ms|
-|[packages/jest-jasmine2/src/__tests__/hooksError.test.ts](#r0s297)|32:white_check_mark:|||51ms|
-|[packages/jest-jasmine2/src/__tests__/iterators.test.ts](#r0s298)|4:white_check_mark:|||43ms|
-|[packages/jest-jasmine2/src/__tests__/itTestError.test.ts](#r0s299)|6:white_check_mark:|||32ms|
-|[packages/jest-jasmine2/src/__tests__/itToTestAlias.test.ts](#r0s300)|1:white_check_mark:|||23ms|
-|[packages/jest-jasmine2/src/__tests__/pTimeout.test.ts](#r0s301)|3:white_check_mark:|||44ms|
-|[packages/jest-jasmine2/src/__tests__/queueRunner.test.ts](#r0s302)|6:white_check_mark:|||93ms|
-|[packages/jest-jasmine2/src/__tests__/reporter.test.ts](#r0s303)|1:white_check_mark:|||107ms|
-|[packages/jest-jasmine2/src/__tests__/Suite.test.ts](#r0s304)|1:white_check_mark:|||84ms|
-|[packages/jest-jasmine2/src/__tests__/todoError.test.ts](#r0s305)|3:white_check_mark:|||27ms|
-|[packages/jest-leak-detector/src/__tests__/index.test.ts](#r0s306)|6:white_check_mark:|||986ms|
-|[packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts](#r0s307)|11:white_check_mark:|||49ms|
-|[packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceableDom.test.ts](#r0s308)|2:white_check_mark:|||48ms|
-|[packages/jest-matcher-utils/src/__tests__/index.test.ts](#r0s309)|48:white_check_mark:|||391ms|
-|[packages/jest-matcher-utils/src/__tests__/printDiffOrStringify.test.ts](#r0s310)|21:white_check_mark:|||114ms|
-|[packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts](#r0s311)|17:white_check_mark:|||111ms|
-|[packages/jest-message-util/src/__tests__/messages.test.ts](#r0s312)|11:white_check_mark:|||205ms|
-|[packages/jest-mock/src/__tests__/index.test.ts](#r0s313)|84:white_check_mark:|||509ms|
-|[packages/jest-regex-util/src/__tests__/index.test.ts](#r0s314)|8:white_check_mark:|||56ms|
-|[packages/jest-repl/src/__tests__/jest_repl.test.js](#r0s315)|1:white_check_mark:|||1s|
-|[packages/jest-repl/src/__tests__/runtime_cli.test.js](#r0s316)|4:white_check_mark:|||4s|
-|[packages/jest-reporters/src/__tests__/CoverageReporter.test.js](#r0s317)|12:white_check_mark:|||397ms|
-|[packages/jest-reporters/src/__tests__/CoverageWorker.test.js](#r0s318)|2:white_check_mark:|||199ms|
-|[packages/jest-reporters/src/__tests__/DefaultReporter.test.js](#r0s319)|2:white_check_mark:|||148ms|
-|[packages/jest-reporters/src/__tests__/generateEmptyCoverage.test.js](#r0s320)|3:white_check_mark:|||1s|
-|[packages/jest-reporters/src/__tests__/getResultHeader.test.js](#r0s321)|4:white_check_mark:|||30ms|
-|[packages/jest-reporters/src/__tests__/getSnapshotStatus.test.js](#r0s322)|3:white_check_mark:|||28ms|
-|[packages/jest-reporters/src/__tests__/getSnapshotSummary.test.js](#r0s323)|4:white_check_mark:|||49ms|
-|[packages/jest-reporters/src/__tests__/getWatermarks.test.ts](#r0s324)|2:white_check_mark:|||37ms|
-|[packages/jest-reporters/src/__tests__/NotifyReporter.test.ts](#r0s325)|18:white_check_mark:|||166ms|
-|[packages/jest-reporters/src/__tests__/SummaryReporter.test.js](#r0s326)|4:white_check_mark:|||366ms|
-|[packages/jest-reporters/src/__tests__/utils.test.ts](#r0s327)|10:white_check_mark:|||85ms|
-|[packages/jest-reporters/src/__tests__/VerboseReporter.test.js](#r0s328)|11:white_check_mark:|||425ms|
-|[packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts](#r0s329)|11:white_check_mark:|||666ms|
-|[packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts](#r0s330)|4:white_check_mark:|||36ms|
-|[packages/jest-resolve/src/__tests__/resolve.test.ts](#r0s331)|16:white_check_mark:|||1s|
-|[packages/jest-runner/src/__tests__/testRunner.test.ts](#r0s332)|2:white_check_mark:|||905ms|
-|[packages/jest-runtime/src/__tests__/instrumentation.test.ts](#r0s333)|1:white_check_mark:|||275ms|
-|[packages/jest-runtime/src/__tests__/runtime_create_mock_from_module.test.js](#r0s334)|3:white_check_mark:|||606ms|
-|[packages/jest-runtime/src/__tests__/runtime_environment.test.js](#r0s335)|2:white_check_mark:|||497ms|
-|[packages/jest-runtime/src/__tests__/runtime_internal_module.test.js](#r0s336)|4:white_check_mark:|||727ms|
-|[packages/jest-runtime/src/__tests__/runtime_jest_fn.js](#r0s337)|4:white_check_mark:|||479ms|
-|[packages/jest-runtime/src/__tests__/runtime_jest_spy_on.test.js](#r0s338)|2:white_check_mark:|||521ms|
-|[packages/jest-runtime/src/__tests__/runtime_mock.test.js](#r0s339)|4:white_check_mark:|||743ms|
-|[packages/jest-runtime/src/__tests__/runtime_module_directories.test.js](#r0s340)|4:white_check_mark:|||525ms|
-|[packages/jest-runtime/src/__tests__/runtime_node_path.test.js](#r0s341)|4:white_check_mark:|||1s|
-|[packages/jest-runtime/src/__tests__/runtime_require_actual.test.js](#r0s342)|2:white_check_mark:|||478ms|
-|[packages/jest-runtime/src/__tests__/runtime_require_cache.test.js](#r0s343)|2:white_check_mark:|||454ms|
-|[packages/jest-runtime/src/__tests__/runtime_require_mock.test.js](#r0s344)|13:white_check_mark:|||962ms|
-|[packages/jest-runtime/src/__tests__/runtime_require_module_no_ext.test.js](#r0s345)|1:white_check_mark:|||261ms|
-|[packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js](#r0s346)|6:white_check_mark:|||2s|
-|[packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js](#r0s347)|17:white_check_mark:|||1s|
-|[packages/jest-runtime/src/__tests__/runtime_require_module.test.js](#r0s348)|27:white_check_mark:|||2s|
-|[packages/jest-runtime/src/__tests__/runtime_require_resolve.test.ts](#r0s349)|5:white_check_mark:|||707ms|
-|[packages/jest-runtime/src/__tests__/runtime_wrap.js](#r0s350)|2:white_check_mark:|||263ms|
-|[packages/jest-runtime/src/__tests__/Runtime-sourceMaps.test.js](#r0s351)|1:white_check_mark:|||584ms|
-|[packages/jest-runtime/src/__tests__/Runtime-statics.test.js](#r0s352)|2:white_check_mark:|||162ms|
-|[packages/jest-serializer/src/__tests__/index.test.ts](#r0s353)|17:white_check_mark:|||158ms|
-|[packages/jest-snapshot/src/__tests__/dedentLines.test.ts](#r0s354)|17:white_check_mark:|||94ms|
-|[packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts](#r0s355)|22:white_check_mark:|||1s|
-|[packages/jest-snapshot/src/__tests__/matcher.test.ts](#r0s356)|1:white_check_mark:|||131ms|
-|[packages/jest-snapshot/src/__tests__/mockSerializer.test.ts](#r0s357)|10:white_check_mark:|||45ms|
-|[packages/jest-snapshot/src/__tests__/printSnapshot.test.ts](#r0s358)|71:white_check_mark:|||1s|
-|[packages/jest-snapshot/src/__tests__/SnapshotResolver.test.ts](#r0s359)|10:white_check_mark:|||98ms|
-|[packages/jest-snapshot/src/__tests__/throwMatcher.test.ts](#r0s360)|3:white_check_mark:|||481ms|
-|[packages/jest-snapshot/src/__tests__/utils.test.ts](#r0s361)|26:white_check_mark:|||214ms|
-|[packages/jest-source-map/src/__tests__/getCallsite.test.ts](#r0s362)|3:white_check_mark:|||86ms|
-|[packages/jest-test-result/src/__tests__/formatTestResults.test.ts](#r0s363)|1:white_check_mark:|||53ms|
-|[packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js](#r0s364)|8:white_check_mark:|||251ms|
-|[packages/jest-transform/src/__tests__/ScriptTransformer.test.ts](#r0s365)|22:white_check_mark:|||2s|
-|[packages/jest-transform/src/__tests__/shouldInstrument.test.ts](#r0s366)|25:white_check_mark:|||155ms|
-|[packages/jest-util/src/__tests__/createProcessObject.test.ts](#r0s367)|4:white_check_mark:|||81ms|
-|[packages/jest-util/src/__tests__/deepCyclicCopy.test.ts](#r0s368)|12:white_check_mark:|||86ms|
-|[packages/jest-util/src/__tests__/errorWithStack.test.ts](#r0s369)|1:white_check_mark:|||41ms|
-|[packages/jest-util/src/__tests__/formatTime.test.ts](#r0s370)|11:white_check_mark:|||82ms|
-|[packages/jest-util/src/__tests__/globsToMatcher.test.ts](#r0s371)|4:white_check_mark:|||56ms|
-|[packages/jest-util/src/__tests__/installCommonGlobals.test.ts](#r0s372)|2:white_check_mark:|||68ms|
-|[packages/jest-util/src/__tests__/isInteractive.test.ts](#r0s373)|2:white_check_mark:|||35ms|
-|[packages/jest-util/src/__tests__/isPromise.test.ts](#r0s374)|10:white_check_mark:|||30ms|
-|[packages/jest-validate/src/__tests__/validate.test.ts](#r0s375)|23:white_check_mark:|||283ms|
-|[packages/jest-validate/src/__tests__/validateCLIOptions.test.js](#r0s376)|6:white_check_mark:|||83ms|
-|[packages/jest-watcher/src/lib/__tests__/formatTestNameByPattern.test.ts](#r0s377)|11:white_check_mark:|||129ms|
-|[packages/jest-watcher/src/lib/__tests__/prompt.test.ts](#r0s378)|3:white_check_mark:|||91ms|
-|[packages/jest-watcher/src/lib/__tests__/scroll.test.ts](#r0s379)|5:white_check_mark:|||57ms|
-|[packages/jest-worker/src/__tests__/Farm.test.js](#r0s380)|10:white_check_mark:|||158ms|
-|[packages/jest-worker/src/__tests__/FifoQueue.test.js](#r0s381)|3:white_check_mark:|||48ms|
-|[packages/jest-worker/src/__tests__/index.test.js](#r0s382)|8:white_check_mark:|||230ms|
-|[packages/jest-worker/src/__tests__/PriorityQueue.test.js](#r0s383)|5:white_check_mark:|||63ms|
-|[packages/jest-worker/src/__tests__/process-integration.test.js](#r0s384)|5:white_check_mark:|||62ms|
-|[packages/jest-worker/src/__tests__/thread-integration.test.js](#r0s385)|6:white_check_mark:|||114ms|
-|[packages/jest-worker/src/__tests__/WorkerPool.test.js](#r0s386)|3:white_check_mark:|||51ms|
-|[packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js](#r0s387)|11:white_check_mark:|||653ms|
-|[packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js](#r0s388)|17:white_check_mark:|||184ms|
-|[packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js](#r0s389)|15:white_check_mark:|||258ms|
-|[packages/jest-worker/src/workers/__tests__/processChild.test.js](#r0s390)|10:white_check_mark:|||135ms|
-|[packages/jest-worker/src/workers/__tests__/threadChild.test.js](#r0s391)|10:white_check_mark:|||120ms|
-|[packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts](#r0s392)|38:white_check_mark:|||137ms|
-|[packages/pretty-format/src/__tests__/ConvertAnsi.test.ts](#r0s393)|6:white_check_mark:|||43ms|
-|[packages/pretty-format/src/__tests__/DOMCollection.test.ts](#r0s394)|10:white_check_mark:|||64ms|
-|[packages/pretty-format/src/__tests__/DOMElement.test.ts](#r0s395)|28:white_check_mark:|||148ms|
-|[packages/pretty-format/src/__tests__/Immutable.test.ts](#r0s396)|111:white_check_mark:|||443ms|
-|[packages/pretty-format/src/__tests__/prettyFormat.test.ts](#r0s397)|86:white_check_mark:|||219ms|
-|[packages/pretty-format/src/__tests__/react.test.tsx](#r0s398)|55:white_check_mark:|||325ms|
-|[packages/pretty-format/src/__tests__/ReactElement.test.ts](#r0s399)|3:white_check_mark:|||64ms|
+|[e2e/__tests__/asyncAndCallback.test.ts](#r0s0)|1 :white_check_mark:|||746ms|
+|[e2e/__tests__/asyncRegenerator.test.ts](#r0s1)|1 :white_check_mark:|||4s|
+|[e2e/__tests__/autoClearMocks.test.ts](#r0s2)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/autoResetMocks.test.ts](#r0s3)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/autoRestoreMocks.test.ts](#r0s4)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/babelPluginJestHoist.test.ts](#r0s5)|1 :white_check_mark:|||6s|
+|[e2e/__tests__/badSourceMap.test.ts](#r0s6)|1 :white_check_mark:|||858ms|
+|[e2e/__tests__/beforeAllFiltered.ts](#r0s7)|1 :white_check_mark:|||958ms|
+|[e2e/__tests__/beforeEachQueue.ts](#r0s8)|1 :white_check_mark:||1 :warning:|55ms|
+|[e2e/__tests__/callDoneTwice.test.ts](#r0s9)|1 :white_check_mark:|||882ms|
+|[e2e/__tests__/chaiAssertionLibrary.ts](#r0s10)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/circularInequality.test.ts](#r0s11)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/circusConcurrentEach.test.ts](#r0s12)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/circusDeclarationErrors.test.ts](#r0s13)|1 :white_check_mark:|||869ms|
+|[e2e/__tests__/clearCache.test.ts](#r0s14)|2 :white_check_mark:|||1s|
+|[e2e/__tests__/cliHandlesExactFilenames.test.ts](#r0s15)|2 :white_check_mark:|||1s|
+|[e2e/__tests__/compareDomNodes.test.ts](#r0s16)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/config.test.ts](#r0s17)|6 :white_check_mark:|||4s|
+|[e2e/__tests__/console.test.ts](#r0s18)|7 :white_check_mark:|||8s|
+|[e2e/__tests__/consoleAfterTeardown.test.ts](#r0s19)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/consoleLogOutputWhenRunInBand.test.ts](#r0s20)|1 :white_check_mark:|||793ms|
+|[e2e/__tests__/coverageHandlebars.test.ts](#r0s21)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/coverageRemapping.test.ts](#r0s22)|1 :white_check_mark:|||13s|
+|[e2e/__tests__/coverageReport.test.ts](#r0s23)|12 :white_check_mark:|||22s|
+|[e2e/__tests__/coverageThreshold.test.ts](#r0s24)|5 :white_check_mark:|||5s|
+|[e2e/__tests__/coverageTransformInstrumented.test.ts](#r0s25)|1 :white_check_mark:|||5s|
+|[e2e/__tests__/coverageWithoutTransform.test.ts](#r0s26)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/createProcessObject.test.ts](#r0s27)|1 :white_check_mark:|||908ms|
+|[e2e/__tests__/customInlineSnapshotMatchers.test.ts](#r0s28)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/customMatcherStackTrace.test.ts](#r0s29)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/customReporters.test.ts](#r0s30)|9 :white_check_mark:|||7s|
+|[e2e/__tests__/customResolver.test.ts](#r0s31)|1 :white_check_mark:|||826ms|
+|[e2e/__tests__/customTestSequencers.test.ts](#r0s32)|3 :white_check_mark:|||3s|
+|[e2e/__tests__/debug.test.ts](#r0s33)|1 :white_check_mark:|||899ms|
+|[e2e/__tests__/declarationErrors.test.ts](#r0s34)|3 :white_check_mark:|||2s|
+|[e2e/__tests__/dependencyClash.test.ts](#r0s35)|1 :white_check_mark:|||833ms|
+|[e2e/__tests__/detectOpenHandles.ts](#r0s36)|8 :white_check_mark:|||8s|
+|[e2e/__tests__/domDiffing.test.ts](#r0s37)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/doneInHooks.test.ts](#r0s38)|1 :white_check_mark:|||855ms|
+|[e2e/__tests__/dynamicRequireDependencies.ts](#r0s39)|1 :white_check_mark:|||847ms|
+|[e2e/__tests__/each.test.ts](#r0s40)|7 :white_check_mark:|||5s|
+|[e2e/__tests__/emptyDescribeWithHooks.test.ts](#r0s41)|4 :white_check_mark:|||3s|
+|[e2e/__tests__/emptySuiteError.test.ts](#r0s42)|1 :white_check_mark:|||885ms|
+|[e2e/__tests__/env.test.ts](#r0s43)|6 :white_check_mark:|||5s|
+|[e2e/__tests__/environmentAfterTeardown.test.ts](#r0s44)|1 :white_check_mark:|||892ms|
+|[e2e/__tests__/errorOnDeprecated.test.ts](#r0s45)|1 :white_check_mark:||24 :warning:|56ms|
+|[e2e/__tests__/esmConfigFile.test.ts](#r0s46)|3 :white_check_mark:|||526ms|
+|[e2e/__tests__/executeTestsOnceInMpr.ts](#r0s47)|1 :white_check_mark:|||976ms|
+|[e2e/__tests__/existentRoots.test.ts](#r0s48)|4 :white_check_mark:|||627ms|
+|[e2e/__tests__/expectAsyncMatcher.test.ts](#r0s49)|2 :white_check_mark:|||3s|
+|[e2e/__tests__/expectInVm.test.ts](#r0s50)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/extraGlobals.test.ts](#r0s51)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/failureDetailsProperty.test.ts](#r0s52)|1 :white_check_mark:|||907ms|
+|[e2e/__tests__/failures.test.ts](#r0s53)|7 :white_check_mark:|||10s|
+|[e2e/__tests__/fakePromises.test.ts](#r0s54)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/fatalWorkerError.test.ts](#r0s55)|1 :white_check_mark:|||3s|
+|[e2e/__tests__/filter.test.ts](#r0s56)|7 :white_check_mark:|||5s|
+|[e2e/__tests__/findRelatedFiles.test.ts](#r0s57)|5 :white_check_mark:|||6s|
+|[e2e/__tests__/focusedTests.test.ts](#r0s58)|1 :white_check_mark:|||888ms|
+|[e2e/__tests__/forceExit.test.ts](#r0s59)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/generatorMock.test.ts](#r0s60)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/global-mutation.test.ts](#r0s61)|1 :white_check_mark:|||40ms|
+|[e2e/__tests__/global.test.ts](#r0s62)|1 :white_check_mark:|||31ms|
+|[e2e/__tests__/globals.test.ts](#r0s63)|10 :white_check_mark:|||8s|
+|[e2e/__tests__/globalSetup.test.ts](#r0s64)|10 :white_check_mark:|||14s|
+|[e2e/__tests__/globalTeardown.test.ts](#r0s65)|7 :white_check_mark:|||12s|
+|[e2e/__tests__/hasteMapMockChanged.test.ts](#r0s66)|1 :white_check_mark:|||379ms|
+|[e2e/__tests__/hasteMapSha1.test.ts](#r0s67)|1 :white_check_mark:|||298ms|
+|[e2e/__tests__/hasteMapSize.test.ts](#r0s68)|2 :white_check_mark:|||397ms|
+|[e2e/__tests__/importedGlobals.test.ts](#r0s69)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/injectGlobals.test.ts](#r0s70)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/jasmineAsync.test.ts](#r0s71)|15 :white_check_mark:|||28s|
+|[e2e/__tests__/jasmineAsyncWithPendingDuringTest.ts](#r0s72)|1 :white_check_mark:||1 :warning:|72ms|
+|[e2e/__tests__/jest.config.js.test.ts](#r0s73)|3 :white_check_mark:|||2s|
+|[e2e/__tests__/jest.config.ts.test.ts](#r0s74)|5 :white_check_mark:|||14s|
+|[e2e/__tests__/jestChangedFiles.test.ts](#r0s75)|9 :white_check_mark:|1 :x:||9s|
+|[e2e/__tests__/jestEnvironmentJsdom.test.ts](#r0s76)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/jestRequireActual.test.ts](#r0s77)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/jestRequireMock.test.ts](#r0s78)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/json.test.ts](#r0s79)|2 :white_check_mark:|||29ms|
+|[e2e/__tests__/jsonReporter.test.ts](#r0s80)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/lifecycles.ts](#r0s81)|1 :white_check_mark:|||861ms|
+|[e2e/__tests__/listTests.test.ts](#r0s82)|2 :white_check_mark:|||945ms|
+|[e2e/__tests__/locationInResults.test.ts](#r0s83)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/logHeapUsage.test.ts](#r0s84)|1 :white_check_mark:|||884ms|
+|[e2e/__tests__/mockNames.test.ts](#r0s85)|8 :white_check_mark:|||7s|
+|[e2e/__tests__/modernFakeTimers.test.ts](#r0s86)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/moduleNameMapper.test.ts](#r0s87)|5 :white_check_mark:|||5s|
+|[e2e/__tests__/moduleParentNullInTest.ts](#r0s88)|1 :white_check_mark:|||886ms|
+|[e2e/__tests__/multiProjectRunner.test.ts](#r0s89)|14 :white_check_mark:|||16s|
+|[e2e/__tests__/nativeAsyncMock.test.ts](#r0s90)|1 :white_check_mark:|||55ms|
+|[e2e/__tests__/nativeEsm.test.ts](#r0s91)|2 :white_check_mark:||1 :warning:|905ms|
+|[e2e/__tests__/nativeEsmTypescript.test.ts](#r0s92)|1 :white_check_mark:|||956ms|
+|[e2e/__tests__/nestedEventLoop.test.ts](#r0s93)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/nestedTestDefinitions.test.ts](#r0s94)|4 :white_check_mark:|||5s|
+|[e2e/__tests__/nodePath.test.ts](#r0s95)|1 :white_check_mark:|||866ms|
+|[e2e/__tests__/noTestFound.test.ts](#r0s96)|2 :white_check_mark:|||1s|
+|[e2e/__tests__/noTestsFound.test.ts](#r0s97)|5 :white_check_mark:|||3s|
+|[e2e/__tests__/onlyChanged.test.ts](#r0s98)|8 :white_check_mark:|1 :x:||22s|
+|[e2e/__tests__/onlyFailuresNonWatch.test.ts](#r0s99)|1 :white_check_mark:|||3s|
+|[e2e/__tests__/overrideGlobals.test.ts](#r0s100)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/pnp.test.ts](#r0s101)|1 :white_check_mark:|||3s|
+|[e2e/__tests__/presets.test.ts](#r0s102)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/processExit.test.ts](#r0s103)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/promiseReject.test.ts](#r0s104)|1 :white_check_mark:|||967ms|
+|[e2e/__tests__/regexCharInPath.test.ts](#r0s105)|1 :white_check_mark:|||962ms|
+|[e2e/__tests__/requireAfterTeardown.test.ts](#r0s106)|1 :white_check_mark:|||921ms|
+|[e2e/__tests__/requireMain.test.ts](#r0s107)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/requireMainAfterCreateRequire.test.ts](#r0s108)|1 :white_check_mark:|||966ms|
+|[e2e/__tests__/requireMainIsolateModules.test.ts](#r0s109)|1 :white_check_mark:|||976ms|
+|[e2e/__tests__/requireMainResetModules.test.ts](#r0s110)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/requireV8Module.test.ts](#r0s111)|1 :white_check_mark:|||30ms|
+|[e2e/__tests__/resetModules.test.ts](#r0s112)|1 :white_check_mark:|||926ms|
+|[e2e/__tests__/resolve.test.ts](#r0s113)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/resolveGetPaths.test.ts](#r0s114)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/resolveNodeModule.test.ts](#r0s115)|1 :white_check_mark:|||943ms|
+|[e2e/__tests__/resolveNoFileExtensions.test.ts](#r0s116)|2 :white_check_mark:|||1s|
+|[e2e/__tests__/resolveWithPaths.test.ts](#r0s117)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/runProgrammatically.test.ts](#r0s118)|2 :white_check_mark:|||575ms|
+|[e2e/__tests__/runTestsByPath.test.ts](#r0s119)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/runtimeInternalModuleRegistry.test.ts](#r0s120)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/selectProjects.test.ts](#r0s121)|18 :white_check_mark:|||5s|
+|[e2e/__tests__/setImmediate.test.ts](#r0s122)|1 :white_check_mark:|||904ms|
+|[e2e/__tests__/setupFilesAfterEnvConfig.test.ts](#r0s123)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/showConfig.test.ts](#r0s124)|1 :white_check_mark:|||195ms|
+|[e2e/__tests__/skipBeforeAfterAll.test.ts](#r0s125)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/snapshot-unknown.test.ts](#r0s126)|1 :white_check_mark:|||838ms|
+|[e2e/__tests__/snapshot.test.ts](#r0s127)|9 :white_check_mark:|||14s|
+|[e2e/__tests__/snapshotMockFs.test.ts](#r0s128)|1 :white_check_mark:|||883ms|
+|[e2e/__tests__/snapshotResolver.test.ts](#r0s129)|1 :white_check_mark:|||823ms|
+|[e2e/__tests__/snapshotSerializers.test.ts](#r0s130)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/stackTrace.test.ts](#r0s131)|7 :white_check_mark:|||5s|
+|[e2e/__tests__/stackTraceNoCaptureStackTrace.test.ts](#r0s132)|1 :white_check_mark:|||899ms|
+|[e2e/__tests__/stackTraceSourceMaps.test.ts](#r0s133)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/stackTraceSourceMapsWithCoverage.test.ts](#r0s134)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/supportsDashedArgs.ts](#r0s135)|2 :white_check_mark:|||968ms|
+|[e2e/__tests__/symbol.test.ts](#r0s136)|1 :white_check_mark:|||49ms|
+|[e2e/__tests__/testEnvironment.test.ts](#r0s137)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/testEnvironmentAsync.test.ts](#r0s138)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/testEnvironmentCircus.test.ts](#r0s139)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/testEnvironmentCircusAsync.test.ts](#r0s140)|1 :white_check_mark:|||2s|
+|[e2e/__tests__/testFailureExitCode.test.ts](#r0s141)|2 :white_check_mark:|||4s|
+|[e2e/__tests__/testInRoot.test.ts](#r0s142)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/testNamePattern.test.ts](#r0s143)|1 :white_check_mark:|||859ms|
+|[e2e/__tests__/testNamePatternSkipped.test.ts](#r0s144)|1 :white_check_mark:|||991ms|
+|[e2e/__tests__/testPathPatternReporterMessage.test.ts](#r0s145)|1 :white_check_mark:|||3s|
+|[e2e/__tests__/testResultsProcessor.test.ts](#r0s146)|1 :white_check_mark:|||910ms|
+|[e2e/__tests__/testRetries.test.ts](#r0s147)|4 :white_check_mark:|||3s|
+|[e2e/__tests__/testTodo.test.ts](#r0s148)|5 :white_check_mark:|||4s|
+|[e2e/__tests__/timeouts.test.ts](#r0s149)|4 :white_check_mark:|||4s|
+|[e2e/__tests__/timeoutsLegacy.test.ts](#r0s150)|1 :white_check_mark:||3 :warning:|71ms|
+|[e2e/__tests__/timerResetMocks.test.ts](#r0s151)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/timerUseRealTimers.test.ts](#r0s152)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/toMatchInlineSnapshot.test.ts](#r0s153)|12 :white_check_mark:|||24s|
+|[e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts](#r0s154)|3 :white_check_mark:|||5s|
+|[e2e/__tests__/toMatchSnapshot.test.ts](#r0s155)|9 :white_check_mark:|||17s|
+|[e2e/__tests__/toMatchSnapshotWithRetries.test.ts](#r0s156)|2 :white_check_mark:|||4s|
+|[e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts](#r0s157)|3 :white_check_mark:|||4s|
+|[e2e/__tests__/toThrowErrorMatchingInlineSnapshot.test.ts](#r0s158)|4 :white_check_mark:|||4s|
+|[e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts](#r0s159)|5 :white_check_mark:|||4s|
+|[e2e/__tests__/transform.test.ts](#r0s160)|16 :white_check_mark:|||27s|
+|[e2e/__tests__/transformLinkedModules.test.ts](#r0s161)|1 :white_check_mark:|||783ms|
+|[e2e/__tests__/typescriptCoverage.test.ts](#r0s162)|1 :white_check_mark:|||3s|
+|[e2e/__tests__/unexpectedToken.test.ts](#r0s163)|3 :white_check_mark:|||3s|
+|[e2e/__tests__/useStderr.test.ts](#r0s164)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/v8Coverage.test.ts](#r0s165)|2 :white_check_mark:|||2s|
+|[e2e/__tests__/verbose.test.ts](#r0s166)|1 :white_check_mark:|||683ms|
+|[e2e/__tests__/version.test.ts](#r0s167)|1 :white_check_mark:|||138ms|
+|[e2e/__tests__/watchModeNoAccess.test.ts](#r0s168)|1 :white_check_mark:|||4s|
+|[e2e/__tests__/watchModeOnlyFailed.test.ts](#r0s169)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/watchModePatterns.test.ts](#r0s170)|2 :white_check_mark:|||4s|
+|[e2e/__tests__/watchModeUpdateSnapshot.test.ts](#r0s171)|1 :white_check_mark:|||1s|
+|[e2e/__tests__/workerForceExit.test.ts](#r0s172)|2 :white_check_mark:|||5s|
+|[e2e/__tests__/wrongEnv.test.ts](#r0s173)|5 :white_check_mark:|||4s|
+|[e2e/custom-test-sequencer/a.test.js](#r0s174)|1 :white_check_mark:|||29ms|
+|[e2e/custom-test-sequencer/b.test.js](#r0s175)|1 :white_check_mark:|||21ms|
+|[e2e/custom-test-sequencer/c.test.js](#r0s176)|1 :white_check_mark:|||42ms|
+|[e2e/custom-test-sequencer/d.test.js](#r0s177)|1 :white_check_mark:|||21ms|
+|[e2e/custom-test-sequencer/e.test.js](#r0s178)|1 :white_check_mark:|||27ms|
+|[e2e/test-in-root/spec.js](#r0s179)|1 :white_check_mark:|||19ms|
+|[e2e/test-in-root/test.js](#r0s180)|1 :white_check_mark:|||37ms|
+|[e2e/timer-reset-mocks/after-reset-all-mocks/timerAndMock.test.js](#r0s181)|2 :white_check_mark:|||30ms|
+|[e2e/timer-reset-mocks/with-reset-mocks/timerWithMock.test.js](#r0s182)|1 :white_check_mark:|||34ms|
+|[e2e/v8-coverage/empty-sourcemap/test.ts](#r0s183)|1 :white_check_mark:|||31ms|
+|[examples/angular/app.component.spec.ts](#r0s184)|3 :white_check_mark:|||654ms|
+|[examples/angular/shared/data.service.spec.ts](#r0s185)|2 :white_check_mark:|||431ms|
+|[examples/angular/shared/sub.service.spec.ts](#r0s186)|1 :white_check_mark:|||109ms|
+|[examples/async/__tests__/user.test.js](#r0s187)|8 :white_check_mark:|||96ms|
+|[examples/automatic-mocks/__tests__/automock.test.js](#r0s188)|2 :white_check_mark:|||74ms|
+|[examples/automatic-mocks/__tests__/createMockFromModule.test.js](#r0s189)|2 :white_check_mark:|||115ms|
+|[examples/automatic-mocks/__tests__/disableAutomocking.test.js](#r0s190)|1 :white_check_mark:|||24ms|
+|[examples/enzyme/__tests__/CheckboxWithLabel-test.js](#r0s191)|1 :white_check_mark:|||434ms|
+|[examples/getting-started/sum.test.js](#r0s192)|1 :white_check_mark:|||78ms|
+|[examples/jquery/__tests__/display_user.test.js](#r0s193)|1 :white_check_mark:|||196ms|
+|[examples/jquery/__tests__/fetch_current_user.test.js](#r0s194)|2 :white_check_mark:|||196ms|
+|[examples/manual-mocks/__tests__/file_summarizer.test.js](#r0s195)|1 :white_check_mark:|||87ms|
+|[examples/manual-mocks/__tests__/lodashMocking.test.js](#r0s196)|1 :white_check_mark:|||109ms|
+|[examples/manual-mocks/__tests__/user.test.js](#r0s197)|1 :white_check_mark:|||41ms|
+|[examples/manual-mocks/__tests__/userMocked.test.js](#r0s198)|1 :white_check_mark:|||105ms|
+|[examples/module-mock/__tests__/full_mock.js](#r0s199)|1 :white_check_mark:|||60ms|
+|[examples/module-mock/__tests__/mock_per_test.js](#r0s200)|2 :white_check_mark:|||116ms|
+|[examples/module-mock/__tests__/partial_mock.js](#r0s201)|1 :white_check_mark:|||215ms|
+|[examples/mongodb/__test__/db.test.js](#r0s202)|1 :white_check_mark:|||236ms|
+|[examples/react-native/__tests__/intro.test.js](#r0s203)|4 :white_check_mark:|||9s|
+|[examples/react-testing-library/__tests__/CheckboxWithLabel-test.js](#r0s204)|1 :white_check_mark:|||469ms|
+|[examples/react/__tests__/CheckboxWithLabel-test.js](#r0s205)|1 :white_check_mark:|||256ms|
+|[examples/snapshot/__tests__/clock.react.test.js](#r0s206)|1 :white_check_mark:|||62ms|
+|[examples/snapshot/__tests__/link.react.test.js](#r0s207)|4 :white_check_mark:|||181ms|
+|[examples/timer/__tests__/infinite_timer_game.test.js](#r0s208)|1 :white_check_mark:|||94ms|
+|[examples/timer/__tests__/timer_game.test.js](#r0s209)|3 :white_check_mark:|||74ms|
+|[examples/typescript/__tests__/calc.test.ts](#r0s210)|6 :white_check_mark:|||276ms|
+|[examples/typescript/__tests__/CheckboxWithLabel-test.tsx](#r0s211)|1 :white_check_mark:|||227ms|
+|[examples/typescript/__tests__/sub-test.ts](#r0s212)|1 :white_check_mark:|||43ms|
+|[examples/typescript/__tests__/sum-test.ts](#r0s213)|2 :white_check_mark:|||69ms|
+|[examples/typescript/__tests__/sum.test.js](#r0s214)|2 :white_check_mark:|||100ms|
+|[packages/babel-jest/src/__tests__/index.ts](#r0s215)|6 :white_check_mark:|||371ms|
+|[packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts](#r0s216)|4 :white_check_mark:|||347ms|
+|[packages/diff-sequences/src/__tests__/index.property.test.ts](#r0s217)|7 :white_check_mark:|||357ms|
+|[packages/diff-sequences/src/__tests__/index.test.ts](#r0s218)|48 :white_check_mark:|||195ms|
+|[packages/expect/src/__tests__/assertionCounts.test.ts](#r0s219)|6 :white_check_mark:|||60ms|
+|[packages/expect/src/__tests__/asymmetricMatchers.test.ts](#r0s220)|38 :white_check_mark:|||207ms|
+|[packages/expect/src/__tests__/extend.test.ts](#r0s221)|10 :white_check_mark:|||99ms|
+|[packages/expect/src/__tests__/isError.test.ts](#r0s222)|4 :white_check_mark:|||43ms|
+|[packages/expect/src/__tests__/matchers-toContain.property.test.ts](#r0s223)|2 :white_check_mark:|||236ms|
+|[packages/expect/src/__tests__/matchers-toContainEqual.property.test.ts](#r0s224)|2 :white_check_mark:|||287ms|
+|[packages/expect/src/__tests__/matchers-toEqual.property.test.ts](#r0s225)|2 :white_check_mark:|||1s|
+|[packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts](#r0s226)|3 :white_check_mark:|||394ms|
+|[packages/expect/src/__tests__/matchers.test.js](#r0s227)|592 :white_check_mark:|||862ms|
+|[packages/expect/src/__tests__/spyMatchers.test.ts](#r0s228)|248 :white_check_mark:|||395ms|
+|[packages/expect/src/__tests__/stacktrace.test.ts](#r0s229)|3 :white_check_mark:|||69ms|
+|[packages/expect/src/__tests__/symbolInObjects.test.ts](#r0s230)|3 :white_check_mark:|||33ms|
+|[packages/expect/src/__tests__/toEqual-dom.test.ts](#r0s231)|12 :white_check_mark:|||99ms|
+|[packages/expect/src/__tests__/toThrowMatchers.test.ts](#r0s232)|98 :white_check_mark:|||257ms|
+|[packages/expect/src/__tests__/utils.test.ts](#r0s233)|41 :white_check_mark:|||147ms|
+|[packages/jest-circus/src/__tests__/afterAll.test.ts](#r0s234)|6 :white_check_mark:|||6s|
+|[packages/jest-circus/src/__tests__/baseTest.test.ts](#r0s235)|2 :white_check_mark:|||3s|
+|[packages/jest-circus/src/__tests__/circusItTestError.test.ts](#r0s236)|8 :white_check_mark:|||300ms|
+|[packages/jest-circus/src/__tests__/circusItTodoTestError.test.ts](#r0s237)|3 :white_check_mark:|||81ms|
+|[packages/jest-circus/src/__tests__/hooks.test.ts](#r0s238)|3 :white_check_mark:|||4s|
+|[packages/jest-circus/src/__tests__/hooksError.test.ts](#r0s239)|32 :white_check_mark:|||127ms|
+|[packages/jest-cli/src/__tests__/cli/args.test.ts](#r0s240)|17 :white_check_mark:|||345ms|
+|[packages/jest-cli/src/init/__tests__/init.test.js](#r0s241)|24 :white_check_mark:|||119ms|
+|[packages/jest-cli/src/init/__tests__/modifyPackageJson.test.ts](#r0s242)|4 :white_check_mark:|||30ms|
+|[packages/jest-config/src/__tests__/Defaults.test.ts](#r0s243)|1 :white_check_mark:|||672ms|
+|[packages/jest-config/src/__tests__/getMaxWorkers.test.ts](#r0s244)|7 :white_check_mark:|||67ms|
+|[packages/jest-config/src/__tests__/normalize.test.js](#r0s245)|118 :white_check_mark:|||798ms|
+|[packages/jest-config/src/__tests__/readConfig.test.ts](#r0s246)|1 :white_check_mark:|||76ms|
+|[packages/jest-config/src/__tests__/readConfigs.test.ts](#r0s247)|3 :white_check_mark:|||135ms|
+|[packages/jest-config/src/__tests__/resolveConfigPath.test.ts](#r0s248)|10 :white_check_mark:|||183ms|
+|[packages/jest-config/src/__tests__/setFromArgv.test.ts](#r0s249)|4 :white_check_mark:|||53ms|
+|[packages/jest-config/src/__tests__/validatePattern.test.ts](#r0s250)|4 :white_check_mark:|||52ms|
+|[packages/jest-console/src/__tests__/bufferedConsole.test.ts](#r0s251)|20 :white_check_mark:|||171ms|
+|[packages/jest-console/src/__tests__/CustomConsole.test.ts](#r0s252)|23 :white_check_mark:|||115ms|
+|[packages/jest-console/src/__tests__/getConsoleOutput.test.ts](#r0s253)|12 :white_check_mark:|||56ms|
+|[packages/jest-core/src/__tests__/FailedTestsCache.test.js](#r0s254)|1 :white_check_mark:|||25ms|
+|[packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js](#r0s255)|5 :white_check_mark:|||61ms|
+|[packages/jest-core/src/__tests__/globals.test.ts](#r0s256)|1 :white_check_mark:|||22ms|
+|[packages/jest-core/src/__tests__/runJest.test.js](#r0s257)|2 :white_check_mark:|||261ms|
+|[packages/jest-core/src/__tests__/SearchSource.test.ts](#r0s258)|27 :white_check_mark:|||3s|
+|[packages/jest-core/src/__tests__/SnapshotInteractiveMode.test.js](#r0s259)|13 :white_check_mark:|||89ms|
+|[packages/jest-core/src/__tests__/TestScheduler.test.js](#r0s260)|8 :white_check_mark:|||520ms|
+|[packages/jest-core/src/__tests__/testSchedulerHelper.test.js](#r0s261)|12 :white_check_mark:|||48ms|
+|[packages/jest-core/src/__tests__/watch.test.js](#r0s262)|80 :white_check_mark:|||7s|
+|[packages/jest-core/src/__tests__/watchFileChanges.test.ts](#r0s263)|1 :white_check_mark:|||2s|
+|[packages/jest-core/src/__tests__/watchFilenamePatternMode.test.js](#r0s264)|2 :white_check_mark:|||165ms|
+|[packages/jest-core/src/__tests__/watchTestNamePatternMode.test.js](#r0s265)|1 :white_check_mark:|||246ms|
+|[packages/jest-core/src/lib/__tests__/isValidPath.test.ts](#r0s266)|3 :white_check_mark:|||166ms|
+|[packages/jest-core/src/lib/__tests__/logDebugMessages.test.ts](#r0s267)|3 :white_check_mark:|||48ms|
+|[packages/jest-create-cache-key-function/src/__tests__/index.test.ts](#r0s268)|1 :white_check_mark:|||75ms|
+|[packages/jest-diff/src/__tests__/diff.test.ts](#r0s269)|107 :white_check_mark:|||625ms|
+|[packages/jest-diff/src/__tests__/diffStringsRaw.test.ts](#r0s270)|2 :white_check_mark:|||55ms|
+|[packages/jest-diff/src/__tests__/getAlignedDiffs.test.ts](#r0s271)|24 :white_check_mark:|||72ms|
+|[packages/jest-diff/src/__tests__/joinAlignedDiffs.test.ts](#r0s272)|6 :white_check_mark:|||44ms|
+|[packages/jest-docblock/src/__tests__/index.test.ts](#r0s273)|36 :white_check_mark:|||177ms|
+|[packages/jest-each/src/__tests__/array.test.ts](#r0s274)|159 :white_check_mark:|||192ms|
+|[packages/jest-each/src/__tests__/index.test.ts](#r0s275)|10 :white_check_mark:|||44ms|
+|[packages/jest-each/src/__tests__/template.test.ts](#r0s276)|242 :white_check_mark:|||483ms|
+|[packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts](#r0s277)|2 :white_check_mark:|||783ms|
+|[packages/jest-environment-node/src/__tests__/node_environment.test.ts](#r0s278)|6 :white_check_mark:|||184ms|
+|[packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts](#r0s279)|50 :white_check_mark:|||302ms|
+|[packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts](#r0s280)|40 :white_check_mark:|||317ms|
+|[packages/jest-get-type/src/__tests__/getType.test.ts](#r0s281)|14 :white_check_mark:|||45ms|
+|[packages/jest-get-type/src/__tests__/isPrimitive.test.ts](#r0s282)|18 :white_check_mark:|||36ms|
+|[packages/jest-globals/src/__tests__/index.ts](#r0s283)|1 :white_check_mark:|||533ms|
+|[packages/jest-haste-map/src/__tests__/get_mock_name.test.js](#r0s284)|1 :white_check_mark:|||22ms|
+|[packages/jest-haste-map/src/__tests__/includes_dotfiles.test.ts](#r0s285)|1 :white_check_mark:|||337ms|
+|[packages/jest-haste-map/src/__tests__/index.test.js](#r0s286)|44 :white_check_mark:|||1s|
+|[packages/jest-haste-map/src/__tests__/worker.test.js](#r0s287)|7 :white_check_mark:|||100ms|
+|[packages/jest-haste-map/src/crawlers/__tests__/node.test.js](#r0s288)|10 :white_check_mark:|||170ms|
+|[packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js](#r0s289)|8 :white_check_mark:|||153ms|
+|[packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js](#r0s290)|15 :white_check_mark:|||56ms|
+|[packages/jest-haste-map/src/lib/__tests__/fast_path.test.js](#r0s291)|5 :white_check_mark:|||29ms|
+|[packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js](#r0s292)|1 :white_check_mark:|||35ms|
+|[packages/jest-haste-map/src/lib/__tests__/isRegExpSupported.test.js](#r0s293)|2 :white_check_mark:|||31ms|
+|[packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js](#r0s294)|2 :white_check_mark:|||35ms|
+|[packages/jest-jasmine2/src/__tests__/concurrent.test.ts](#r0s295)|3 :white_check_mark:|||24ms|
+|[packages/jest-jasmine2/src/__tests__/expectationResultFactory.test.ts](#r0s296)|7 :white_check_mark:|||70ms|
+|[packages/jest-jasmine2/src/__tests__/hooksError.test.ts](#r0s297)|32 :white_check_mark:|||51ms|
+|[packages/jest-jasmine2/src/__tests__/iterators.test.ts](#r0s298)|4 :white_check_mark:|||43ms|
+|[packages/jest-jasmine2/src/__tests__/itTestError.test.ts](#r0s299)|6 :white_check_mark:|||32ms|
+|[packages/jest-jasmine2/src/__tests__/itToTestAlias.test.ts](#r0s300)|1 :white_check_mark:|||23ms|
+|[packages/jest-jasmine2/src/__tests__/pTimeout.test.ts](#r0s301)|3 :white_check_mark:|||44ms|
+|[packages/jest-jasmine2/src/__tests__/queueRunner.test.ts](#r0s302)|6 :white_check_mark:|||93ms|
+|[packages/jest-jasmine2/src/__tests__/reporter.test.ts](#r0s303)|1 :white_check_mark:|||107ms|
+|[packages/jest-jasmine2/src/__tests__/Suite.test.ts](#r0s304)|1 :white_check_mark:|||84ms|
+|[packages/jest-jasmine2/src/__tests__/todoError.test.ts](#r0s305)|3 :white_check_mark:|||27ms|
+|[packages/jest-leak-detector/src/__tests__/index.test.ts](#r0s306)|6 :white_check_mark:|||986ms|
+|[packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts](#r0s307)|11 :white_check_mark:|||49ms|
+|[packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceableDom.test.ts](#r0s308)|2 :white_check_mark:|||48ms|
+|[packages/jest-matcher-utils/src/__tests__/index.test.ts](#r0s309)|48 :white_check_mark:|||391ms|
+|[packages/jest-matcher-utils/src/__tests__/printDiffOrStringify.test.ts](#r0s310)|21 :white_check_mark:|||114ms|
+|[packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts](#r0s311)|17 :white_check_mark:|||111ms|
+|[packages/jest-message-util/src/__tests__/messages.test.ts](#r0s312)|11 :white_check_mark:|||205ms|
+|[packages/jest-mock/src/__tests__/index.test.ts](#r0s313)|84 :white_check_mark:|||509ms|
+|[packages/jest-regex-util/src/__tests__/index.test.ts](#r0s314)|8 :white_check_mark:|||56ms|
+|[packages/jest-repl/src/__tests__/jest_repl.test.js](#r0s315)|1 :white_check_mark:|||1s|
+|[packages/jest-repl/src/__tests__/runtime_cli.test.js](#r0s316)|4 :white_check_mark:|||4s|
+|[packages/jest-reporters/src/__tests__/CoverageReporter.test.js](#r0s317)|12 :white_check_mark:|||397ms|
+|[packages/jest-reporters/src/__tests__/CoverageWorker.test.js](#r0s318)|2 :white_check_mark:|||199ms|
+|[packages/jest-reporters/src/__tests__/DefaultReporter.test.js](#r0s319)|2 :white_check_mark:|||148ms|
+|[packages/jest-reporters/src/__tests__/generateEmptyCoverage.test.js](#r0s320)|3 :white_check_mark:|||1s|
+|[packages/jest-reporters/src/__tests__/getResultHeader.test.js](#r0s321)|4 :white_check_mark:|||30ms|
+|[packages/jest-reporters/src/__tests__/getSnapshotStatus.test.js](#r0s322)|3 :white_check_mark:|||28ms|
+|[packages/jest-reporters/src/__tests__/getSnapshotSummary.test.js](#r0s323)|4 :white_check_mark:|||49ms|
+|[packages/jest-reporters/src/__tests__/getWatermarks.test.ts](#r0s324)|2 :white_check_mark:|||37ms|
+|[packages/jest-reporters/src/__tests__/NotifyReporter.test.ts](#r0s325)|18 :white_check_mark:|||166ms|
+|[packages/jest-reporters/src/__tests__/SummaryReporter.test.js](#r0s326)|4 :white_check_mark:|||366ms|
+|[packages/jest-reporters/src/__tests__/utils.test.ts](#r0s327)|10 :white_check_mark:|||85ms|
+|[packages/jest-reporters/src/__tests__/VerboseReporter.test.js](#r0s328)|11 :white_check_mark:|||425ms|
+|[packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts](#r0s329)|11 :white_check_mark:|||666ms|
+|[packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts](#r0s330)|4 :white_check_mark:|||36ms|
+|[packages/jest-resolve/src/__tests__/resolve.test.ts](#r0s331)|16 :white_check_mark:|||1s|
+|[packages/jest-runner/src/__tests__/testRunner.test.ts](#r0s332)|2 :white_check_mark:|||905ms|
+|[packages/jest-runtime/src/__tests__/instrumentation.test.ts](#r0s333)|1 :white_check_mark:|||275ms|
+|[packages/jest-runtime/src/__tests__/runtime_create_mock_from_module.test.js](#r0s334)|3 :white_check_mark:|||606ms|
+|[packages/jest-runtime/src/__tests__/runtime_environment.test.js](#r0s335)|2 :white_check_mark:|||497ms|
+|[packages/jest-runtime/src/__tests__/runtime_internal_module.test.js](#r0s336)|4 :white_check_mark:|||727ms|
+|[packages/jest-runtime/src/__tests__/runtime_jest_fn.js](#r0s337)|4 :white_check_mark:|||479ms|
+|[packages/jest-runtime/src/__tests__/runtime_jest_spy_on.test.js](#r0s338)|2 :white_check_mark:|||521ms|
+|[packages/jest-runtime/src/__tests__/runtime_mock.test.js](#r0s339)|4 :white_check_mark:|||743ms|
+|[packages/jest-runtime/src/__tests__/runtime_module_directories.test.js](#r0s340)|4 :white_check_mark:|||525ms|
+|[packages/jest-runtime/src/__tests__/runtime_node_path.test.js](#r0s341)|4 :white_check_mark:|||1s|
+|[packages/jest-runtime/src/__tests__/runtime_require_actual.test.js](#r0s342)|2 :white_check_mark:|||478ms|
+|[packages/jest-runtime/src/__tests__/runtime_require_cache.test.js](#r0s343)|2 :white_check_mark:|||454ms|
+|[packages/jest-runtime/src/__tests__/runtime_require_mock.test.js](#r0s344)|13 :white_check_mark:|||962ms|
+|[packages/jest-runtime/src/__tests__/runtime_require_module_no_ext.test.js](#r0s345)|1 :white_check_mark:|||261ms|
+|[packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js](#r0s346)|6 :white_check_mark:|||2s|
+|[packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js](#r0s347)|17 :white_check_mark:|||1s|
+|[packages/jest-runtime/src/__tests__/runtime_require_module.test.js](#r0s348)|27 :white_check_mark:|||2s|
+|[packages/jest-runtime/src/__tests__/runtime_require_resolve.test.ts](#r0s349)|5 :white_check_mark:|||707ms|
+|[packages/jest-runtime/src/__tests__/runtime_wrap.js](#r0s350)|2 :white_check_mark:|||263ms|
+|[packages/jest-runtime/src/__tests__/Runtime-sourceMaps.test.js](#r0s351)|1 :white_check_mark:|||584ms|
+|[packages/jest-runtime/src/__tests__/Runtime-statics.test.js](#r0s352)|2 :white_check_mark:|||162ms|
+|[packages/jest-serializer/src/__tests__/index.test.ts](#r0s353)|17 :white_check_mark:|||158ms|
+|[packages/jest-snapshot/src/__tests__/dedentLines.test.ts](#r0s354)|17 :white_check_mark:|||94ms|
+|[packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts](#r0s355)|22 :white_check_mark:|||1s|
+|[packages/jest-snapshot/src/__tests__/matcher.test.ts](#r0s356)|1 :white_check_mark:|||131ms|
+|[packages/jest-snapshot/src/__tests__/mockSerializer.test.ts](#r0s357)|10 :white_check_mark:|||45ms|
+|[packages/jest-snapshot/src/__tests__/printSnapshot.test.ts](#r0s358)|71 :white_check_mark:|||1s|
+|[packages/jest-snapshot/src/__tests__/SnapshotResolver.test.ts](#r0s359)|10 :white_check_mark:|||98ms|
+|[packages/jest-snapshot/src/__tests__/throwMatcher.test.ts](#r0s360)|3 :white_check_mark:|||481ms|
+|[packages/jest-snapshot/src/__tests__/utils.test.ts](#r0s361)|26 :white_check_mark:|||214ms|
+|[packages/jest-source-map/src/__tests__/getCallsite.test.ts](#r0s362)|3 :white_check_mark:|||86ms|
+|[packages/jest-test-result/src/__tests__/formatTestResults.test.ts](#r0s363)|1 :white_check_mark:|||53ms|
+|[packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js](#r0s364)|8 :white_check_mark:|||251ms|
+|[packages/jest-transform/src/__tests__/ScriptTransformer.test.ts](#r0s365)|22 :white_check_mark:|||2s|
+|[packages/jest-transform/src/__tests__/shouldInstrument.test.ts](#r0s366)|25 :white_check_mark:|||155ms|
+|[packages/jest-util/src/__tests__/createProcessObject.test.ts](#r0s367)|4 :white_check_mark:|||81ms|
+|[packages/jest-util/src/__tests__/deepCyclicCopy.test.ts](#r0s368)|12 :white_check_mark:|||86ms|
+|[packages/jest-util/src/__tests__/errorWithStack.test.ts](#r0s369)|1 :white_check_mark:|||41ms|
+|[packages/jest-util/src/__tests__/formatTime.test.ts](#r0s370)|11 :white_check_mark:|||82ms|
+|[packages/jest-util/src/__tests__/globsToMatcher.test.ts](#r0s371)|4 :white_check_mark:|||56ms|
+|[packages/jest-util/src/__tests__/installCommonGlobals.test.ts](#r0s372)|2 :white_check_mark:|||68ms|
+|[packages/jest-util/src/__tests__/isInteractive.test.ts](#r0s373)|2 :white_check_mark:|||35ms|
+|[packages/jest-util/src/__tests__/isPromise.test.ts](#r0s374)|10 :white_check_mark:|||30ms|
+|[packages/jest-validate/src/__tests__/validate.test.ts](#r0s375)|23 :white_check_mark:|||283ms|
+|[packages/jest-validate/src/__tests__/validateCLIOptions.test.js](#r0s376)|6 :white_check_mark:|||83ms|
+|[packages/jest-watcher/src/lib/__tests__/formatTestNameByPattern.test.ts](#r0s377)|11 :white_check_mark:|||129ms|
+|[packages/jest-watcher/src/lib/__tests__/prompt.test.ts](#r0s378)|3 :white_check_mark:|||91ms|
+|[packages/jest-watcher/src/lib/__tests__/scroll.test.ts](#r0s379)|5 :white_check_mark:|||57ms|
+|[packages/jest-worker/src/__tests__/Farm.test.js](#r0s380)|10 :white_check_mark:|||158ms|
+|[packages/jest-worker/src/__tests__/FifoQueue.test.js](#r0s381)|3 :white_check_mark:|||48ms|
+|[packages/jest-worker/src/__tests__/index.test.js](#r0s382)|8 :white_check_mark:|||230ms|
+|[packages/jest-worker/src/__tests__/PriorityQueue.test.js](#r0s383)|5 :white_check_mark:|||63ms|
+|[packages/jest-worker/src/__tests__/process-integration.test.js](#r0s384)|5 :white_check_mark:|||62ms|
+|[packages/jest-worker/src/__tests__/thread-integration.test.js](#r0s385)|6 :white_check_mark:|||114ms|
+|[packages/jest-worker/src/__tests__/WorkerPool.test.js](#r0s386)|3 :white_check_mark:|||51ms|
+|[packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js](#r0s387)|11 :white_check_mark:|||653ms|
+|[packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js](#r0s388)|17 :white_check_mark:|||184ms|
+|[packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js](#r0s389)|15 :white_check_mark:|||258ms|
+|[packages/jest-worker/src/workers/__tests__/processChild.test.js](#r0s390)|10 :white_check_mark:|||135ms|
+|[packages/jest-worker/src/workers/__tests__/threadChild.test.js](#r0s391)|10 :white_check_mark:|||120ms|
+|[packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts](#r0s392)|38 :white_check_mark:|||137ms|
+|[packages/pretty-format/src/__tests__/ConvertAnsi.test.ts](#r0s393)|6 :white_check_mark:|||43ms|
+|[packages/pretty-format/src/__tests__/DOMCollection.test.ts](#r0s394)|10 :white_check_mark:|||64ms|
+|[packages/pretty-format/src/__tests__/DOMElement.test.ts](#r0s395)|28 :white_check_mark:|||148ms|
+|[packages/pretty-format/src/__tests__/Immutable.test.ts](#r0s396)|111 :white_check_mark:|||443ms|
+|[packages/pretty-format/src/__tests__/prettyFormat.test.ts](#r0s397)|86 :white_check_mark:|||219ms|
+|[packages/pretty-format/src/__tests__/react.test.tsx](#r0s398)|55 :white_check_mark:|||325ms|
+|[packages/pretty-format/src/__tests__/ReactElement.test.ts](#r0s399)|3 :white_check_mark:|||64ms|
 ### :white_check_mark: <a id="user-content-r0s0" href="#r0s0">e2e/__tests__/asyncAndCallback.test.ts</a>
 ```
 :white_check_mark: errors when a test both returns a promise and takes a callback

--- a/__tests__/__outputs__/jest-test-results.md
+++ b/__tests__/__outputs__/jest-test-results.md
@@ -6,406 +6,884 @@
 **4239** tests were completed in **166s** with **4207** passed, **2** failed and **30** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|e2e/__tests__/asyncAndCallback.test.ts|1:white_check_mark:|||746ms|
-|e2e/__tests__/asyncRegenerator.test.ts|1:white_check_mark:|||4s|
-|e2e/__tests__/autoClearMocks.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/autoResetMocks.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/autoRestoreMocks.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/babelPluginJestHoist.test.ts|1:white_check_mark:|||6s|
-|e2e/__tests__/badSourceMap.test.ts|1:white_check_mark:|||858ms|
-|e2e/__tests__/beforeAllFiltered.ts|1:white_check_mark:|||958ms|
-|e2e/__tests__/beforeEachQueue.ts|1:white_check_mark:||1:warning:|55ms|
-|e2e/__tests__/callDoneTwice.test.ts|1:white_check_mark:|||882ms|
-|e2e/__tests__/chaiAssertionLibrary.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/circularInequality.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/circusConcurrentEach.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/circusDeclarationErrors.test.ts|1:white_check_mark:|||869ms|
-|e2e/__tests__/clearCache.test.ts|2:white_check_mark:|||1s|
-|e2e/__tests__/cliHandlesExactFilenames.test.ts|2:white_check_mark:|||1s|
-|e2e/__tests__/compareDomNodes.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/config.test.ts|6:white_check_mark:|||4s|
-|e2e/__tests__/console.test.ts|7:white_check_mark:|||8s|
-|e2e/__tests__/consoleAfterTeardown.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/consoleLogOutputWhenRunInBand.test.ts|1:white_check_mark:|||793ms|
-|e2e/__tests__/coverageHandlebars.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/coverageRemapping.test.ts|1:white_check_mark:|||13s|
-|e2e/__tests__/coverageReport.test.ts|12:white_check_mark:|||22s|
-|e2e/__tests__/coverageThreshold.test.ts|5:white_check_mark:|||5s|
-|e2e/__tests__/coverageTransformInstrumented.test.ts|1:white_check_mark:|||5s|
-|e2e/__tests__/coverageWithoutTransform.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/createProcessObject.test.ts|1:white_check_mark:|||908ms|
-|e2e/__tests__/customInlineSnapshotMatchers.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/customMatcherStackTrace.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/customReporters.test.ts|9:white_check_mark:|||7s|
-|e2e/__tests__/customResolver.test.ts|1:white_check_mark:|||826ms|
-|e2e/__tests__/customTestSequencers.test.ts|3:white_check_mark:|||3s|
-|e2e/__tests__/debug.test.ts|1:white_check_mark:|||899ms|
-|e2e/__tests__/declarationErrors.test.ts|3:white_check_mark:|||2s|
-|e2e/__tests__/dependencyClash.test.ts|1:white_check_mark:|||833ms|
-|e2e/__tests__/detectOpenHandles.ts|8:white_check_mark:|||8s|
-|e2e/__tests__/domDiffing.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/doneInHooks.test.ts|1:white_check_mark:|||855ms|
-|e2e/__tests__/dynamicRequireDependencies.ts|1:white_check_mark:|||847ms|
-|e2e/__tests__/each.test.ts|7:white_check_mark:|||5s|
-|e2e/__tests__/emptyDescribeWithHooks.test.ts|4:white_check_mark:|||3s|
-|e2e/__tests__/emptySuiteError.test.ts|1:white_check_mark:|||885ms|
-|e2e/__tests__/env.test.ts|6:white_check_mark:|||5s|
-|e2e/__tests__/environmentAfterTeardown.test.ts|1:white_check_mark:|||892ms|
-|e2e/__tests__/errorOnDeprecated.test.ts|1:white_check_mark:||24:warning:|56ms|
-|e2e/__tests__/esmConfigFile.test.ts|3:white_check_mark:|||526ms|
-|e2e/__tests__/executeTestsOnceInMpr.ts|1:white_check_mark:|||976ms|
-|e2e/__tests__/existentRoots.test.ts|4:white_check_mark:|||627ms|
-|e2e/__tests__/expectAsyncMatcher.test.ts|2:white_check_mark:|||3s|
-|e2e/__tests__/expectInVm.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/extraGlobals.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/failureDetailsProperty.test.ts|1:white_check_mark:|||907ms|
-|e2e/__tests__/failures.test.ts|7:white_check_mark:|||10s|
-|e2e/__tests__/fakePromises.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/fatalWorkerError.test.ts|1:white_check_mark:|||3s|
-|e2e/__tests__/filter.test.ts|7:white_check_mark:|||5s|
-|e2e/__tests__/findRelatedFiles.test.ts|5:white_check_mark:|||6s|
-|e2e/__tests__/focusedTests.test.ts|1:white_check_mark:|||888ms|
-|e2e/__tests__/forceExit.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/generatorMock.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/global-mutation.test.ts|1:white_check_mark:|||40ms|
-|e2e/__tests__/global.test.ts|1:white_check_mark:|||31ms|
-|e2e/__tests__/globals.test.ts|10:white_check_mark:|||8s|
-|e2e/__tests__/globalSetup.test.ts|10:white_check_mark:|||14s|
-|e2e/__tests__/globalTeardown.test.ts|7:white_check_mark:|||12s|
-|e2e/__tests__/hasteMapMockChanged.test.ts|1:white_check_mark:|||379ms|
-|e2e/__tests__/hasteMapSha1.test.ts|1:white_check_mark:|||298ms|
-|e2e/__tests__/hasteMapSize.test.ts|2:white_check_mark:|||397ms|
-|e2e/__tests__/importedGlobals.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/injectGlobals.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/jasmineAsync.test.ts|15:white_check_mark:|||28s|
-|e2e/__tests__/jasmineAsyncWithPendingDuringTest.ts|1:white_check_mark:||1:warning:|72ms|
-|e2e/__tests__/jest.config.js.test.ts|3:white_check_mark:|||2s|
-|e2e/__tests__/jest.config.ts.test.ts|5:white_check_mark:|||14s|
+|[e2e/__tests__/asyncAndCallback.test.ts](#r0s0)|1:white_check_mark:|||746ms|
+|[e2e/__tests__/asyncRegenerator.test.ts](#r0s1)|1:white_check_mark:|||4s|
+|[e2e/__tests__/autoClearMocks.test.ts](#r0s2)|2:white_check_mark:|||2s|
+|[e2e/__tests__/autoResetMocks.test.ts](#r0s3)|2:white_check_mark:|||2s|
+|[e2e/__tests__/autoRestoreMocks.test.ts](#r0s4)|2:white_check_mark:|||2s|
+|[e2e/__tests__/babelPluginJestHoist.test.ts](#r0s5)|1:white_check_mark:|||6s|
+|[e2e/__tests__/badSourceMap.test.ts](#r0s6)|1:white_check_mark:|||858ms|
+|[e2e/__tests__/beforeAllFiltered.ts](#r0s7)|1:white_check_mark:|||958ms|
+|[e2e/__tests__/beforeEachQueue.ts](#r0s8)|1:white_check_mark:||1:warning:|55ms|
+|[e2e/__tests__/callDoneTwice.test.ts](#r0s9)|1:white_check_mark:|||882ms|
+|[e2e/__tests__/chaiAssertionLibrary.ts](#r0s10)|1:white_check_mark:|||2s|
+|[e2e/__tests__/circularInequality.test.ts](#r0s11)|1:white_check_mark:|||1s|
+|[e2e/__tests__/circusConcurrentEach.test.ts](#r0s12)|2:white_check_mark:|||2s|
+|[e2e/__tests__/circusDeclarationErrors.test.ts](#r0s13)|1:white_check_mark:|||869ms|
+|[e2e/__tests__/clearCache.test.ts](#r0s14)|2:white_check_mark:|||1s|
+|[e2e/__tests__/cliHandlesExactFilenames.test.ts](#r0s15)|2:white_check_mark:|||1s|
+|[e2e/__tests__/compareDomNodes.test.ts](#r0s16)|1:white_check_mark:|||1s|
+|[e2e/__tests__/config.test.ts](#r0s17)|6:white_check_mark:|||4s|
+|[e2e/__tests__/console.test.ts](#r0s18)|7:white_check_mark:|||8s|
+|[e2e/__tests__/consoleAfterTeardown.test.ts](#r0s19)|1:white_check_mark:|||1s|
+|[e2e/__tests__/consoleLogOutputWhenRunInBand.test.ts](#r0s20)|1:white_check_mark:|||793ms|
+|[e2e/__tests__/coverageHandlebars.test.ts](#r0s21)|1:white_check_mark:|||2s|
+|[e2e/__tests__/coverageRemapping.test.ts](#r0s22)|1:white_check_mark:|||13s|
+|[e2e/__tests__/coverageReport.test.ts](#r0s23)|12:white_check_mark:|||22s|
+|[e2e/__tests__/coverageThreshold.test.ts](#r0s24)|5:white_check_mark:|||5s|
+|[e2e/__tests__/coverageTransformInstrumented.test.ts](#r0s25)|1:white_check_mark:|||5s|
+|[e2e/__tests__/coverageWithoutTransform.test.ts](#r0s26)|1:white_check_mark:|||1s|
+|[e2e/__tests__/createProcessObject.test.ts](#r0s27)|1:white_check_mark:|||908ms|
+|[e2e/__tests__/customInlineSnapshotMatchers.test.ts](#r0s28)|1:white_check_mark:|||2s|
+|[e2e/__tests__/customMatcherStackTrace.test.ts](#r0s29)|2:white_check_mark:|||2s|
+|[e2e/__tests__/customReporters.test.ts](#r0s30)|9:white_check_mark:|||7s|
+|[e2e/__tests__/customResolver.test.ts](#r0s31)|1:white_check_mark:|||826ms|
+|[e2e/__tests__/customTestSequencers.test.ts](#r0s32)|3:white_check_mark:|||3s|
+|[e2e/__tests__/debug.test.ts](#r0s33)|1:white_check_mark:|||899ms|
+|[e2e/__tests__/declarationErrors.test.ts](#r0s34)|3:white_check_mark:|||2s|
+|[e2e/__tests__/dependencyClash.test.ts](#r0s35)|1:white_check_mark:|||833ms|
+|[e2e/__tests__/detectOpenHandles.ts](#r0s36)|8:white_check_mark:|||8s|
+|[e2e/__tests__/domDiffing.test.ts](#r0s37)|1:white_check_mark:|||1s|
+|[e2e/__tests__/doneInHooks.test.ts](#r0s38)|1:white_check_mark:|||855ms|
+|[e2e/__tests__/dynamicRequireDependencies.ts](#r0s39)|1:white_check_mark:|||847ms|
+|[e2e/__tests__/each.test.ts](#r0s40)|7:white_check_mark:|||5s|
+|[e2e/__tests__/emptyDescribeWithHooks.test.ts](#r0s41)|4:white_check_mark:|||3s|
+|[e2e/__tests__/emptySuiteError.test.ts](#r0s42)|1:white_check_mark:|||885ms|
+|[e2e/__tests__/env.test.ts](#r0s43)|6:white_check_mark:|||5s|
+|[e2e/__tests__/environmentAfterTeardown.test.ts](#r0s44)|1:white_check_mark:|||892ms|
+|[e2e/__tests__/errorOnDeprecated.test.ts](#r0s45)|1:white_check_mark:||24:warning:|56ms|
+|[e2e/__tests__/esmConfigFile.test.ts](#r0s46)|3:white_check_mark:|||526ms|
+|[e2e/__tests__/executeTestsOnceInMpr.ts](#r0s47)|1:white_check_mark:|||976ms|
+|[e2e/__tests__/existentRoots.test.ts](#r0s48)|4:white_check_mark:|||627ms|
+|[e2e/__tests__/expectAsyncMatcher.test.ts](#r0s49)|2:white_check_mark:|||3s|
+|[e2e/__tests__/expectInVm.test.ts](#r0s50)|1:white_check_mark:|||2s|
+|[e2e/__tests__/extraGlobals.test.ts](#r0s51)|1:white_check_mark:|||1s|
+|[e2e/__tests__/failureDetailsProperty.test.ts](#r0s52)|1:white_check_mark:|||907ms|
+|[e2e/__tests__/failures.test.ts](#r0s53)|7:white_check_mark:|||10s|
+|[e2e/__tests__/fakePromises.test.ts](#r0s54)|2:white_check_mark:|||2s|
+|[e2e/__tests__/fatalWorkerError.test.ts](#r0s55)|1:white_check_mark:|||3s|
+|[e2e/__tests__/filter.test.ts](#r0s56)|7:white_check_mark:|||5s|
+|[e2e/__tests__/findRelatedFiles.test.ts](#r0s57)|5:white_check_mark:|||6s|
+|[e2e/__tests__/focusedTests.test.ts](#r0s58)|1:white_check_mark:|||888ms|
+|[e2e/__tests__/forceExit.test.ts](#r0s59)|1:white_check_mark:|||2s|
+|[e2e/__tests__/generatorMock.test.ts](#r0s60)|1:white_check_mark:|||1s|
+|[e2e/__tests__/global-mutation.test.ts](#r0s61)|1:white_check_mark:|||40ms|
+|[e2e/__tests__/global.test.ts](#r0s62)|1:white_check_mark:|||31ms|
+|[e2e/__tests__/globals.test.ts](#r0s63)|10:white_check_mark:|||8s|
+|[e2e/__tests__/globalSetup.test.ts](#r0s64)|10:white_check_mark:|||14s|
+|[e2e/__tests__/globalTeardown.test.ts](#r0s65)|7:white_check_mark:|||12s|
+|[e2e/__tests__/hasteMapMockChanged.test.ts](#r0s66)|1:white_check_mark:|||379ms|
+|[e2e/__tests__/hasteMapSha1.test.ts](#r0s67)|1:white_check_mark:|||298ms|
+|[e2e/__tests__/hasteMapSize.test.ts](#r0s68)|2:white_check_mark:|||397ms|
+|[e2e/__tests__/importedGlobals.test.ts](#r0s69)|1:white_check_mark:|||1s|
+|[e2e/__tests__/injectGlobals.test.ts](#r0s70)|2:white_check_mark:|||2s|
+|[e2e/__tests__/jasmineAsync.test.ts](#r0s71)|15:white_check_mark:|||28s|
+|[e2e/__tests__/jasmineAsyncWithPendingDuringTest.ts](#r0s72)|1:white_check_mark:||1:warning:|72ms|
+|[e2e/__tests__/jest.config.js.test.ts](#r0s73)|3:white_check_mark:|||2s|
+|[e2e/__tests__/jest.config.ts.test.ts](#r0s74)|5:white_check_mark:|||14s|
 |[e2e/__tests__/jestChangedFiles.test.ts](#r0s75)|9:white_check_mark:|1:x:||9s|
-|e2e/__tests__/jestEnvironmentJsdom.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/jestRequireActual.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/jestRequireMock.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/json.test.ts|2:white_check_mark:|||29ms|
-|e2e/__tests__/jsonReporter.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/lifecycles.ts|1:white_check_mark:|||861ms|
-|e2e/__tests__/listTests.test.ts|2:white_check_mark:|||945ms|
-|e2e/__tests__/locationInResults.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/logHeapUsage.test.ts|1:white_check_mark:|||884ms|
-|e2e/__tests__/mockNames.test.ts|8:white_check_mark:|||7s|
-|e2e/__tests__/modernFakeTimers.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/moduleNameMapper.test.ts|5:white_check_mark:|||5s|
-|e2e/__tests__/moduleParentNullInTest.ts|1:white_check_mark:|||886ms|
-|e2e/__tests__/multiProjectRunner.test.ts|14:white_check_mark:|||16s|
-|e2e/__tests__/nativeAsyncMock.test.ts|1:white_check_mark:|||55ms|
-|e2e/__tests__/nativeEsm.test.ts|2:white_check_mark:||1:warning:|905ms|
-|e2e/__tests__/nativeEsmTypescript.test.ts|1:white_check_mark:|||956ms|
-|e2e/__tests__/nestedEventLoop.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/nestedTestDefinitions.test.ts|4:white_check_mark:|||5s|
-|e2e/__tests__/nodePath.test.ts|1:white_check_mark:|||866ms|
-|e2e/__tests__/noTestFound.test.ts|2:white_check_mark:|||1s|
-|e2e/__tests__/noTestsFound.test.ts|5:white_check_mark:|||3s|
+|[e2e/__tests__/jestEnvironmentJsdom.test.ts](#r0s76)|1:white_check_mark:|||2s|
+|[e2e/__tests__/jestRequireActual.test.ts](#r0s77)|1:white_check_mark:|||2s|
+|[e2e/__tests__/jestRequireMock.test.ts](#r0s78)|1:white_check_mark:|||2s|
+|[e2e/__tests__/json.test.ts](#r0s79)|2:white_check_mark:|||29ms|
+|[e2e/__tests__/jsonReporter.test.ts](#r0s80)|2:white_check_mark:|||2s|
+|[e2e/__tests__/lifecycles.ts](#r0s81)|1:white_check_mark:|||861ms|
+|[e2e/__tests__/listTests.test.ts](#r0s82)|2:white_check_mark:|||945ms|
+|[e2e/__tests__/locationInResults.test.ts](#r0s83)|2:white_check_mark:|||2s|
+|[e2e/__tests__/logHeapUsage.test.ts](#r0s84)|1:white_check_mark:|||884ms|
+|[e2e/__tests__/mockNames.test.ts](#r0s85)|8:white_check_mark:|||7s|
+|[e2e/__tests__/modernFakeTimers.test.ts](#r0s86)|2:white_check_mark:|||2s|
+|[e2e/__tests__/moduleNameMapper.test.ts](#r0s87)|5:white_check_mark:|||5s|
+|[e2e/__tests__/moduleParentNullInTest.ts](#r0s88)|1:white_check_mark:|||886ms|
+|[e2e/__tests__/multiProjectRunner.test.ts](#r0s89)|14:white_check_mark:|||16s|
+|[e2e/__tests__/nativeAsyncMock.test.ts](#r0s90)|1:white_check_mark:|||55ms|
+|[e2e/__tests__/nativeEsm.test.ts](#r0s91)|2:white_check_mark:||1:warning:|905ms|
+|[e2e/__tests__/nativeEsmTypescript.test.ts](#r0s92)|1:white_check_mark:|||956ms|
+|[e2e/__tests__/nestedEventLoop.test.ts](#r0s93)|1:white_check_mark:|||1s|
+|[e2e/__tests__/nestedTestDefinitions.test.ts](#r0s94)|4:white_check_mark:|||5s|
+|[e2e/__tests__/nodePath.test.ts](#r0s95)|1:white_check_mark:|||866ms|
+|[e2e/__tests__/noTestFound.test.ts](#r0s96)|2:white_check_mark:|||1s|
+|[e2e/__tests__/noTestsFound.test.ts](#r0s97)|5:white_check_mark:|||3s|
 |[e2e/__tests__/onlyChanged.test.ts](#r0s98)|8:white_check_mark:|1:x:||22s|
-|e2e/__tests__/onlyFailuresNonWatch.test.ts|1:white_check_mark:|||3s|
-|e2e/__tests__/overrideGlobals.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/pnp.test.ts|1:white_check_mark:|||3s|
-|e2e/__tests__/presets.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/processExit.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/promiseReject.test.ts|1:white_check_mark:|||967ms|
-|e2e/__tests__/regexCharInPath.test.ts|1:white_check_mark:|||962ms|
-|e2e/__tests__/requireAfterTeardown.test.ts|1:white_check_mark:|||921ms|
-|e2e/__tests__/requireMain.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/requireMainAfterCreateRequire.test.ts|1:white_check_mark:|||966ms|
-|e2e/__tests__/requireMainIsolateModules.test.ts|1:white_check_mark:|||976ms|
-|e2e/__tests__/requireMainResetModules.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/requireV8Module.test.ts|1:white_check_mark:|||30ms|
-|e2e/__tests__/resetModules.test.ts|1:white_check_mark:|||926ms|
-|e2e/__tests__/resolve.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/resolveGetPaths.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/resolveNodeModule.test.ts|1:white_check_mark:|||943ms|
-|e2e/__tests__/resolveNoFileExtensions.test.ts|2:white_check_mark:|||1s|
-|e2e/__tests__/resolveWithPaths.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/runProgrammatically.test.ts|2:white_check_mark:|||575ms|
-|e2e/__tests__/runTestsByPath.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/runtimeInternalModuleRegistry.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/selectProjects.test.ts|18:white_check_mark:|||5s|
-|e2e/__tests__/setImmediate.test.ts|1:white_check_mark:|||904ms|
-|e2e/__tests__/setupFilesAfterEnvConfig.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/showConfig.test.ts|1:white_check_mark:|||195ms|
-|e2e/__tests__/skipBeforeAfterAll.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/snapshot-unknown.test.ts|1:white_check_mark:|||838ms|
-|e2e/__tests__/snapshot.test.ts|9:white_check_mark:|||14s|
-|e2e/__tests__/snapshotMockFs.test.ts|1:white_check_mark:|||883ms|
-|e2e/__tests__/snapshotResolver.test.ts|1:white_check_mark:|||823ms|
-|e2e/__tests__/snapshotSerializers.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/stackTrace.test.ts|7:white_check_mark:|||5s|
-|e2e/__tests__/stackTraceNoCaptureStackTrace.test.ts|1:white_check_mark:|||899ms|
-|e2e/__tests__/stackTraceSourceMaps.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/stackTraceSourceMapsWithCoverage.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/supportsDashedArgs.ts|2:white_check_mark:|||968ms|
-|e2e/__tests__/symbol.test.ts|1:white_check_mark:|||49ms|
-|e2e/__tests__/testEnvironment.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/testEnvironmentAsync.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/testEnvironmentCircus.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/testEnvironmentCircusAsync.test.ts|1:white_check_mark:|||2s|
-|e2e/__tests__/testFailureExitCode.test.ts|2:white_check_mark:|||4s|
-|e2e/__tests__/testInRoot.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/testNamePattern.test.ts|1:white_check_mark:|||859ms|
-|e2e/__tests__/testNamePatternSkipped.test.ts|1:white_check_mark:|||991ms|
-|e2e/__tests__/testPathPatternReporterMessage.test.ts|1:white_check_mark:|||3s|
-|e2e/__tests__/testResultsProcessor.test.ts|1:white_check_mark:|||910ms|
-|e2e/__tests__/testRetries.test.ts|4:white_check_mark:|||3s|
-|e2e/__tests__/testTodo.test.ts|5:white_check_mark:|||4s|
-|e2e/__tests__/timeouts.test.ts|4:white_check_mark:|||4s|
-|e2e/__tests__/timeoutsLegacy.test.ts|1:white_check_mark:||3:warning:|71ms|
-|e2e/__tests__/timerResetMocks.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/timerUseRealTimers.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/toMatchInlineSnapshot.test.ts|12:white_check_mark:|||24s|
-|e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts|3:white_check_mark:|||5s|
-|e2e/__tests__/toMatchSnapshot.test.ts|9:white_check_mark:|||17s|
-|e2e/__tests__/toMatchSnapshotWithRetries.test.ts|2:white_check_mark:|||4s|
-|e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts|3:white_check_mark:|||4s|
-|e2e/__tests__/toThrowErrorMatchingInlineSnapshot.test.ts|4:white_check_mark:|||4s|
-|e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts|5:white_check_mark:|||4s|
-|e2e/__tests__/transform.test.ts|16:white_check_mark:|||27s|
-|e2e/__tests__/transformLinkedModules.test.ts|1:white_check_mark:|||783ms|
-|e2e/__tests__/typescriptCoverage.test.ts|1:white_check_mark:|||3s|
-|e2e/__tests__/unexpectedToken.test.ts|3:white_check_mark:|||3s|
-|e2e/__tests__/useStderr.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/v8Coverage.test.ts|2:white_check_mark:|||2s|
-|e2e/__tests__/verbose.test.ts|1:white_check_mark:|||683ms|
-|e2e/__tests__/version.test.ts|1:white_check_mark:|||138ms|
-|e2e/__tests__/watchModeNoAccess.test.ts|1:white_check_mark:|||4s|
-|e2e/__tests__/watchModeOnlyFailed.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/watchModePatterns.test.ts|2:white_check_mark:|||4s|
-|e2e/__tests__/watchModeUpdateSnapshot.test.ts|1:white_check_mark:|||1s|
-|e2e/__tests__/workerForceExit.test.ts|2:white_check_mark:|||5s|
-|e2e/__tests__/wrongEnv.test.ts|5:white_check_mark:|||4s|
-|e2e/custom-test-sequencer/a.test.js|1:white_check_mark:|||29ms|
-|e2e/custom-test-sequencer/b.test.js|1:white_check_mark:|||21ms|
-|e2e/custom-test-sequencer/c.test.js|1:white_check_mark:|||42ms|
-|e2e/custom-test-sequencer/d.test.js|1:white_check_mark:|||21ms|
-|e2e/custom-test-sequencer/e.test.js|1:white_check_mark:|||27ms|
-|e2e/test-in-root/spec.js|1:white_check_mark:|||19ms|
-|e2e/test-in-root/test.js|1:white_check_mark:|||37ms|
-|e2e/timer-reset-mocks/after-reset-all-mocks/timerAndMock.test.js|2:white_check_mark:|||30ms|
-|e2e/timer-reset-mocks/with-reset-mocks/timerWithMock.test.js|1:white_check_mark:|||34ms|
-|e2e/v8-coverage/empty-sourcemap/test.ts|1:white_check_mark:|||31ms|
-|examples/angular/app.component.spec.ts|3:white_check_mark:|||654ms|
-|examples/angular/shared/data.service.spec.ts|2:white_check_mark:|||431ms|
-|examples/angular/shared/sub.service.spec.ts|1:white_check_mark:|||109ms|
-|examples/async/__tests__/user.test.js|8:white_check_mark:|||96ms|
-|examples/automatic-mocks/__tests__/automock.test.js|2:white_check_mark:|||74ms|
-|examples/automatic-mocks/__tests__/createMockFromModule.test.js|2:white_check_mark:|||115ms|
-|examples/automatic-mocks/__tests__/disableAutomocking.test.js|1:white_check_mark:|||24ms|
-|examples/enzyme/__tests__/CheckboxWithLabel-test.js|1:white_check_mark:|||434ms|
-|examples/getting-started/sum.test.js|1:white_check_mark:|||78ms|
-|examples/jquery/__tests__/display_user.test.js|1:white_check_mark:|||196ms|
-|examples/jquery/__tests__/fetch_current_user.test.js|2:white_check_mark:|||196ms|
-|examples/manual-mocks/__tests__/file_summarizer.test.js|1:white_check_mark:|||87ms|
-|examples/manual-mocks/__tests__/lodashMocking.test.js|1:white_check_mark:|||109ms|
-|examples/manual-mocks/__tests__/user.test.js|1:white_check_mark:|||41ms|
-|examples/manual-mocks/__tests__/userMocked.test.js|1:white_check_mark:|||105ms|
-|examples/module-mock/__tests__/full_mock.js|1:white_check_mark:|||60ms|
-|examples/module-mock/__tests__/mock_per_test.js|2:white_check_mark:|||116ms|
-|examples/module-mock/__tests__/partial_mock.js|1:white_check_mark:|||215ms|
-|examples/mongodb/__test__/db.test.js|1:white_check_mark:|||236ms|
-|examples/react-native/__tests__/intro.test.js|4:white_check_mark:|||9s|
-|examples/react-testing-library/__tests__/CheckboxWithLabel-test.js|1:white_check_mark:|||469ms|
-|examples/react/__tests__/CheckboxWithLabel-test.js|1:white_check_mark:|||256ms|
-|examples/snapshot/__tests__/clock.react.test.js|1:white_check_mark:|||62ms|
-|examples/snapshot/__tests__/link.react.test.js|4:white_check_mark:|||181ms|
-|examples/timer/__tests__/infinite_timer_game.test.js|1:white_check_mark:|||94ms|
-|examples/timer/__tests__/timer_game.test.js|3:white_check_mark:|||74ms|
-|examples/typescript/__tests__/calc.test.ts|6:white_check_mark:|||276ms|
-|examples/typescript/__tests__/CheckboxWithLabel-test.tsx|1:white_check_mark:|||227ms|
-|examples/typescript/__tests__/sub-test.ts|1:white_check_mark:|||43ms|
-|examples/typescript/__tests__/sum-test.ts|2:white_check_mark:|||69ms|
-|examples/typescript/__tests__/sum.test.js|2:white_check_mark:|||100ms|
-|packages/babel-jest/src/__tests__/index.ts|6:white_check_mark:|||371ms|
-|packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts|4:white_check_mark:|||347ms|
-|packages/diff-sequences/src/__tests__/index.property.test.ts|7:white_check_mark:|||357ms|
-|packages/diff-sequences/src/__tests__/index.test.ts|48:white_check_mark:|||195ms|
-|packages/expect/src/__tests__/assertionCounts.test.ts|6:white_check_mark:|||60ms|
-|packages/expect/src/__tests__/asymmetricMatchers.test.ts|38:white_check_mark:|||207ms|
-|packages/expect/src/__tests__/extend.test.ts|10:white_check_mark:|||99ms|
-|packages/expect/src/__tests__/isError.test.ts|4:white_check_mark:|||43ms|
-|packages/expect/src/__tests__/matchers-toContain.property.test.ts|2:white_check_mark:|||236ms|
-|packages/expect/src/__tests__/matchers-toContainEqual.property.test.ts|2:white_check_mark:|||287ms|
-|packages/expect/src/__tests__/matchers-toEqual.property.test.ts|2:white_check_mark:|||1s|
-|packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts|3:white_check_mark:|||394ms|
-|packages/expect/src/__tests__/matchers.test.js|592:white_check_mark:|||862ms|
-|packages/expect/src/__tests__/spyMatchers.test.ts|248:white_check_mark:|||395ms|
-|packages/expect/src/__tests__/stacktrace.test.ts|3:white_check_mark:|||69ms|
-|packages/expect/src/__tests__/symbolInObjects.test.ts|3:white_check_mark:|||33ms|
-|packages/expect/src/__tests__/toEqual-dom.test.ts|12:white_check_mark:|||99ms|
-|packages/expect/src/__tests__/toThrowMatchers.test.ts|98:white_check_mark:|||257ms|
-|packages/expect/src/__tests__/utils.test.ts|41:white_check_mark:|||147ms|
-|packages/jest-circus/src/__tests__/afterAll.test.ts|6:white_check_mark:|||6s|
-|packages/jest-circus/src/__tests__/baseTest.test.ts|2:white_check_mark:|||3s|
-|packages/jest-circus/src/__tests__/circusItTestError.test.ts|8:white_check_mark:|||300ms|
-|packages/jest-circus/src/__tests__/circusItTodoTestError.test.ts|3:white_check_mark:|||81ms|
-|packages/jest-circus/src/__tests__/hooks.test.ts|3:white_check_mark:|||4s|
-|packages/jest-circus/src/__tests__/hooksError.test.ts|32:white_check_mark:|||127ms|
-|packages/jest-cli/src/__tests__/cli/args.test.ts|17:white_check_mark:|||345ms|
-|packages/jest-cli/src/init/__tests__/init.test.js|24:white_check_mark:|||119ms|
-|packages/jest-cli/src/init/__tests__/modifyPackageJson.test.ts|4:white_check_mark:|||30ms|
-|packages/jest-config/src/__tests__/Defaults.test.ts|1:white_check_mark:|||672ms|
-|packages/jest-config/src/__tests__/getMaxWorkers.test.ts|7:white_check_mark:|||67ms|
-|packages/jest-config/src/__tests__/normalize.test.js|118:white_check_mark:|||798ms|
-|packages/jest-config/src/__tests__/readConfig.test.ts|1:white_check_mark:|||76ms|
-|packages/jest-config/src/__tests__/readConfigs.test.ts|3:white_check_mark:|||135ms|
-|packages/jest-config/src/__tests__/resolveConfigPath.test.ts|10:white_check_mark:|||183ms|
-|packages/jest-config/src/__tests__/setFromArgv.test.ts|4:white_check_mark:|||53ms|
-|packages/jest-config/src/__tests__/validatePattern.test.ts|4:white_check_mark:|||52ms|
-|packages/jest-console/src/__tests__/bufferedConsole.test.ts|20:white_check_mark:|||171ms|
-|packages/jest-console/src/__tests__/CustomConsole.test.ts|23:white_check_mark:|||115ms|
-|packages/jest-console/src/__tests__/getConsoleOutput.test.ts|12:white_check_mark:|||56ms|
-|packages/jest-core/src/__tests__/FailedTestsCache.test.js|1:white_check_mark:|||25ms|
-|packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js|5:white_check_mark:|||61ms|
-|packages/jest-core/src/__tests__/globals.test.ts|1:white_check_mark:|||22ms|
-|packages/jest-core/src/__tests__/runJest.test.js|2:white_check_mark:|||261ms|
-|packages/jest-core/src/__tests__/SearchSource.test.ts|27:white_check_mark:|||3s|
-|packages/jest-core/src/__tests__/SnapshotInteractiveMode.test.js|13:white_check_mark:|||89ms|
-|packages/jest-core/src/__tests__/TestScheduler.test.js|8:white_check_mark:|||520ms|
-|packages/jest-core/src/__tests__/testSchedulerHelper.test.js|12:white_check_mark:|||48ms|
-|packages/jest-core/src/__tests__/watch.test.js|80:white_check_mark:|||7s|
-|packages/jest-core/src/__tests__/watchFileChanges.test.ts|1:white_check_mark:|||2s|
-|packages/jest-core/src/__tests__/watchFilenamePatternMode.test.js|2:white_check_mark:|||165ms|
-|packages/jest-core/src/__tests__/watchTestNamePatternMode.test.js|1:white_check_mark:|||246ms|
-|packages/jest-core/src/lib/__tests__/isValidPath.test.ts|3:white_check_mark:|||166ms|
-|packages/jest-core/src/lib/__tests__/logDebugMessages.test.ts|3:white_check_mark:|||48ms|
-|packages/jest-create-cache-key-function/src/__tests__/index.test.ts|1:white_check_mark:|||75ms|
-|packages/jest-diff/src/__tests__/diff.test.ts|107:white_check_mark:|||625ms|
-|packages/jest-diff/src/__tests__/diffStringsRaw.test.ts|2:white_check_mark:|||55ms|
-|packages/jest-diff/src/__tests__/getAlignedDiffs.test.ts|24:white_check_mark:|||72ms|
-|packages/jest-diff/src/__tests__/joinAlignedDiffs.test.ts|6:white_check_mark:|||44ms|
-|packages/jest-docblock/src/__tests__/index.test.ts|36:white_check_mark:|||177ms|
-|packages/jest-each/src/__tests__/array.test.ts|159:white_check_mark:|||192ms|
-|packages/jest-each/src/__tests__/index.test.ts|10:white_check_mark:|||44ms|
-|packages/jest-each/src/__tests__/template.test.ts|242:white_check_mark:|||483ms|
-|packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts|2:white_check_mark:|||783ms|
-|packages/jest-environment-node/src/__tests__/node_environment.test.ts|6:white_check_mark:|||184ms|
-|packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts|50:white_check_mark:|||302ms|
-|packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts|40:white_check_mark:|||317ms|
-|packages/jest-get-type/src/__tests__/getType.test.ts|14:white_check_mark:|||45ms|
-|packages/jest-get-type/src/__tests__/isPrimitive.test.ts|18:white_check_mark:|||36ms|
-|packages/jest-globals/src/__tests__/index.ts|1:white_check_mark:|||533ms|
-|packages/jest-haste-map/src/__tests__/get_mock_name.test.js|1:white_check_mark:|||22ms|
-|packages/jest-haste-map/src/__tests__/includes_dotfiles.test.ts|1:white_check_mark:|||337ms|
-|packages/jest-haste-map/src/__tests__/index.test.js|44:white_check_mark:|||1s|
-|packages/jest-haste-map/src/__tests__/worker.test.js|7:white_check_mark:|||100ms|
-|packages/jest-haste-map/src/crawlers/__tests__/node.test.js|10:white_check_mark:|||170ms|
-|packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js|8:white_check_mark:|||153ms|
-|packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js|15:white_check_mark:|||56ms|
-|packages/jest-haste-map/src/lib/__tests__/fast_path.test.js|5:white_check_mark:|||29ms|
-|packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js|1:white_check_mark:|||35ms|
-|packages/jest-haste-map/src/lib/__tests__/isRegExpSupported.test.js|2:white_check_mark:|||31ms|
-|packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js|2:white_check_mark:|||35ms|
-|packages/jest-jasmine2/src/__tests__/concurrent.test.ts|3:white_check_mark:|||24ms|
-|packages/jest-jasmine2/src/__tests__/expectationResultFactory.test.ts|7:white_check_mark:|||70ms|
-|packages/jest-jasmine2/src/__tests__/hooksError.test.ts|32:white_check_mark:|||51ms|
-|packages/jest-jasmine2/src/__tests__/iterators.test.ts|4:white_check_mark:|||43ms|
-|packages/jest-jasmine2/src/__tests__/itTestError.test.ts|6:white_check_mark:|||32ms|
-|packages/jest-jasmine2/src/__tests__/itToTestAlias.test.ts|1:white_check_mark:|||23ms|
-|packages/jest-jasmine2/src/__tests__/pTimeout.test.ts|3:white_check_mark:|||44ms|
-|packages/jest-jasmine2/src/__tests__/queueRunner.test.ts|6:white_check_mark:|||93ms|
-|packages/jest-jasmine2/src/__tests__/reporter.test.ts|1:white_check_mark:|||107ms|
-|packages/jest-jasmine2/src/__tests__/Suite.test.ts|1:white_check_mark:|||84ms|
-|packages/jest-jasmine2/src/__tests__/todoError.test.ts|3:white_check_mark:|||27ms|
-|packages/jest-leak-detector/src/__tests__/index.test.ts|6:white_check_mark:|||986ms|
-|packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts|11:white_check_mark:|||49ms|
-|packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceableDom.test.ts|2:white_check_mark:|||48ms|
-|packages/jest-matcher-utils/src/__tests__/index.test.ts|48:white_check_mark:|||391ms|
-|packages/jest-matcher-utils/src/__tests__/printDiffOrStringify.test.ts|21:white_check_mark:|||114ms|
-|packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts|17:white_check_mark:|||111ms|
-|packages/jest-message-util/src/__tests__/messages.test.ts|11:white_check_mark:|||205ms|
-|packages/jest-mock/src/__tests__/index.test.ts|84:white_check_mark:|||509ms|
-|packages/jest-regex-util/src/__tests__/index.test.ts|8:white_check_mark:|||56ms|
-|packages/jest-repl/src/__tests__/jest_repl.test.js|1:white_check_mark:|||1s|
-|packages/jest-repl/src/__tests__/runtime_cli.test.js|4:white_check_mark:|||4s|
-|packages/jest-reporters/src/__tests__/CoverageReporter.test.js|12:white_check_mark:|||397ms|
-|packages/jest-reporters/src/__tests__/CoverageWorker.test.js|2:white_check_mark:|||199ms|
-|packages/jest-reporters/src/__tests__/DefaultReporter.test.js|2:white_check_mark:|||148ms|
-|packages/jest-reporters/src/__tests__/generateEmptyCoverage.test.js|3:white_check_mark:|||1s|
-|packages/jest-reporters/src/__tests__/getResultHeader.test.js|4:white_check_mark:|||30ms|
-|packages/jest-reporters/src/__tests__/getSnapshotStatus.test.js|3:white_check_mark:|||28ms|
-|packages/jest-reporters/src/__tests__/getSnapshotSummary.test.js|4:white_check_mark:|||49ms|
-|packages/jest-reporters/src/__tests__/getWatermarks.test.ts|2:white_check_mark:|||37ms|
-|packages/jest-reporters/src/__tests__/NotifyReporter.test.ts|18:white_check_mark:|||166ms|
-|packages/jest-reporters/src/__tests__/SummaryReporter.test.js|4:white_check_mark:|||366ms|
-|packages/jest-reporters/src/__tests__/utils.test.ts|10:white_check_mark:|||85ms|
-|packages/jest-reporters/src/__tests__/VerboseReporter.test.js|11:white_check_mark:|||425ms|
-|packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts|11:white_check_mark:|||666ms|
-|packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts|4:white_check_mark:|||36ms|
-|packages/jest-resolve/src/__tests__/resolve.test.ts|16:white_check_mark:|||1s|
-|packages/jest-runner/src/__tests__/testRunner.test.ts|2:white_check_mark:|||905ms|
-|packages/jest-runtime/src/__tests__/instrumentation.test.ts|1:white_check_mark:|||275ms|
-|packages/jest-runtime/src/__tests__/runtime_create_mock_from_module.test.js|3:white_check_mark:|||606ms|
-|packages/jest-runtime/src/__tests__/runtime_environment.test.js|2:white_check_mark:|||497ms|
-|packages/jest-runtime/src/__tests__/runtime_internal_module.test.js|4:white_check_mark:|||727ms|
-|packages/jest-runtime/src/__tests__/runtime_jest_fn.js|4:white_check_mark:|||479ms|
-|packages/jest-runtime/src/__tests__/runtime_jest_spy_on.test.js|2:white_check_mark:|||521ms|
-|packages/jest-runtime/src/__tests__/runtime_mock.test.js|4:white_check_mark:|||743ms|
-|packages/jest-runtime/src/__tests__/runtime_module_directories.test.js|4:white_check_mark:|||525ms|
-|packages/jest-runtime/src/__tests__/runtime_node_path.test.js|4:white_check_mark:|||1s|
-|packages/jest-runtime/src/__tests__/runtime_require_actual.test.js|2:white_check_mark:|||478ms|
-|packages/jest-runtime/src/__tests__/runtime_require_cache.test.js|2:white_check_mark:|||454ms|
-|packages/jest-runtime/src/__tests__/runtime_require_mock.test.js|13:white_check_mark:|||962ms|
-|packages/jest-runtime/src/__tests__/runtime_require_module_no_ext.test.js|1:white_check_mark:|||261ms|
-|packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js|6:white_check_mark:|||2s|
-|packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js|17:white_check_mark:|||1s|
-|packages/jest-runtime/src/__tests__/runtime_require_module.test.js|27:white_check_mark:|||2s|
-|packages/jest-runtime/src/__tests__/runtime_require_resolve.test.ts|5:white_check_mark:|||707ms|
-|packages/jest-runtime/src/__tests__/runtime_wrap.js|2:white_check_mark:|||263ms|
-|packages/jest-runtime/src/__tests__/Runtime-sourceMaps.test.js|1:white_check_mark:|||584ms|
-|packages/jest-runtime/src/__tests__/Runtime-statics.test.js|2:white_check_mark:|||162ms|
-|packages/jest-serializer/src/__tests__/index.test.ts|17:white_check_mark:|||158ms|
-|packages/jest-snapshot/src/__tests__/dedentLines.test.ts|17:white_check_mark:|||94ms|
-|packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts|22:white_check_mark:|||1s|
-|packages/jest-snapshot/src/__tests__/matcher.test.ts|1:white_check_mark:|||131ms|
-|packages/jest-snapshot/src/__tests__/mockSerializer.test.ts|10:white_check_mark:|||45ms|
-|packages/jest-snapshot/src/__tests__/printSnapshot.test.ts|71:white_check_mark:|||1s|
-|packages/jest-snapshot/src/__tests__/SnapshotResolver.test.ts|10:white_check_mark:|||98ms|
-|packages/jest-snapshot/src/__tests__/throwMatcher.test.ts|3:white_check_mark:|||481ms|
-|packages/jest-snapshot/src/__tests__/utils.test.ts|26:white_check_mark:|||214ms|
-|packages/jest-source-map/src/__tests__/getCallsite.test.ts|3:white_check_mark:|||86ms|
-|packages/jest-test-result/src/__tests__/formatTestResults.test.ts|1:white_check_mark:|||53ms|
-|packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js|8:white_check_mark:|||251ms|
-|packages/jest-transform/src/__tests__/ScriptTransformer.test.ts|22:white_check_mark:|||2s|
-|packages/jest-transform/src/__tests__/shouldInstrument.test.ts|25:white_check_mark:|||155ms|
-|packages/jest-util/src/__tests__/createProcessObject.test.ts|4:white_check_mark:|||81ms|
-|packages/jest-util/src/__tests__/deepCyclicCopy.test.ts|12:white_check_mark:|||86ms|
-|packages/jest-util/src/__tests__/errorWithStack.test.ts|1:white_check_mark:|||41ms|
-|packages/jest-util/src/__tests__/formatTime.test.ts|11:white_check_mark:|||82ms|
-|packages/jest-util/src/__tests__/globsToMatcher.test.ts|4:white_check_mark:|||56ms|
-|packages/jest-util/src/__tests__/installCommonGlobals.test.ts|2:white_check_mark:|||68ms|
-|packages/jest-util/src/__tests__/isInteractive.test.ts|2:white_check_mark:|||35ms|
-|packages/jest-util/src/__tests__/isPromise.test.ts|10:white_check_mark:|||30ms|
-|packages/jest-validate/src/__tests__/validate.test.ts|23:white_check_mark:|||283ms|
-|packages/jest-validate/src/__tests__/validateCLIOptions.test.js|6:white_check_mark:|||83ms|
-|packages/jest-watcher/src/lib/__tests__/formatTestNameByPattern.test.ts|11:white_check_mark:|||129ms|
-|packages/jest-watcher/src/lib/__tests__/prompt.test.ts|3:white_check_mark:|||91ms|
-|packages/jest-watcher/src/lib/__tests__/scroll.test.ts|5:white_check_mark:|||57ms|
-|packages/jest-worker/src/__tests__/Farm.test.js|10:white_check_mark:|||158ms|
-|packages/jest-worker/src/__tests__/FifoQueue.test.js|3:white_check_mark:|||48ms|
-|packages/jest-worker/src/__tests__/index.test.js|8:white_check_mark:|||230ms|
-|packages/jest-worker/src/__tests__/PriorityQueue.test.js|5:white_check_mark:|||63ms|
-|packages/jest-worker/src/__tests__/process-integration.test.js|5:white_check_mark:|||62ms|
-|packages/jest-worker/src/__tests__/thread-integration.test.js|6:white_check_mark:|||114ms|
-|packages/jest-worker/src/__tests__/WorkerPool.test.js|3:white_check_mark:|||51ms|
-|packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js|11:white_check_mark:|||653ms|
-|packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js|17:white_check_mark:|||184ms|
-|packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js|15:white_check_mark:|||258ms|
-|packages/jest-worker/src/workers/__tests__/processChild.test.js|10:white_check_mark:|||135ms|
-|packages/jest-worker/src/workers/__tests__/threadChild.test.js|10:white_check_mark:|||120ms|
-|packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts|38:white_check_mark:|||137ms|
-|packages/pretty-format/src/__tests__/ConvertAnsi.test.ts|6:white_check_mark:|||43ms|
-|packages/pretty-format/src/__tests__/DOMCollection.test.ts|10:white_check_mark:|||64ms|
-|packages/pretty-format/src/__tests__/DOMElement.test.ts|28:white_check_mark:|||148ms|
-|packages/pretty-format/src/__tests__/Immutable.test.ts|111:white_check_mark:|||443ms|
-|packages/pretty-format/src/__tests__/prettyFormat.test.ts|86:white_check_mark:|||219ms|
-|packages/pretty-format/src/__tests__/react.test.tsx|55:white_check_mark:|||325ms|
-|packages/pretty-format/src/__tests__/ReactElement.test.ts|3:white_check_mark:|||64ms|
+|[e2e/__tests__/onlyFailuresNonWatch.test.ts](#r0s99)|1:white_check_mark:|||3s|
+|[e2e/__tests__/overrideGlobals.test.ts](#r0s100)|2:white_check_mark:|||2s|
+|[e2e/__tests__/pnp.test.ts](#r0s101)|1:white_check_mark:|||3s|
+|[e2e/__tests__/presets.test.ts](#r0s102)|2:white_check_mark:|||2s|
+|[e2e/__tests__/processExit.test.ts](#r0s103)|1:white_check_mark:|||1s|
+|[e2e/__tests__/promiseReject.test.ts](#r0s104)|1:white_check_mark:|||967ms|
+|[e2e/__tests__/regexCharInPath.test.ts](#r0s105)|1:white_check_mark:|||962ms|
+|[e2e/__tests__/requireAfterTeardown.test.ts](#r0s106)|1:white_check_mark:|||921ms|
+|[e2e/__tests__/requireMain.test.ts](#r0s107)|1:white_check_mark:|||1s|
+|[e2e/__tests__/requireMainAfterCreateRequire.test.ts](#r0s108)|1:white_check_mark:|||966ms|
+|[e2e/__tests__/requireMainIsolateModules.test.ts](#r0s109)|1:white_check_mark:|||976ms|
+|[e2e/__tests__/requireMainResetModules.test.ts](#r0s110)|2:white_check_mark:|||2s|
+|[e2e/__tests__/requireV8Module.test.ts](#r0s111)|1:white_check_mark:|||30ms|
+|[e2e/__tests__/resetModules.test.ts](#r0s112)|1:white_check_mark:|||926ms|
+|[e2e/__tests__/resolve.test.ts](#r0s113)|1:white_check_mark:|||2s|
+|[e2e/__tests__/resolveGetPaths.test.ts](#r0s114)|1:white_check_mark:|||1s|
+|[e2e/__tests__/resolveNodeModule.test.ts](#r0s115)|1:white_check_mark:|||943ms|
+|[e2e/__tests__/resolveNoFileExtensions.test.ts](#r0s116)|2:white_check_mark:|||1s|
+|[e2e/__tests__/resolveWithPaths.test.ts](#r0s117)|1:white_check_mark:|||1s|
+|[e2e/__tests__/runProgrammatically.test.ts](#r0s118)|2:white_check_mark:|||575ms|
+|[e2e/__tests__/runTestsByPath.test.ts](#r0s119)|1:white_check_mark:|||2s|
+|[e2e/__tests__/runtimeInternalModuleRegistry.test.ts](#r0s120)|1:white_check_mark:|||1s|
+|[e2e/__tests__/selectProjects.test.ts](#r0s121)|18:white_check_mark:|||5s|
+|[e2e/__tests__/setImmediate.test.ts](#r0s122)|1:white_check_mark:|||904ms|
+|[e2e/__tests__/setupFilesAfterEnvConfig.test.ts](#r0s123)|2:white_check_mark:|||2s|
+|[e2e/__tests__/showConfig.test.ts](#r0s124)|1:white_check_mark:|||195ms|
+|[e2e/__tests__/skipBeforeAfterAll.test.ts](#r0s125)|1:white_check_mark:|||1s|
+|[e2e/__tests__/snapshot-unknown.test.ts](#r0s126)|1:white_check_mark:|||838ms|
+|[e2e/__tests__/snapshot.test.ts](#r0s127)|9:white_check_mark:|||14s|
+|[e2e/__tests__/snapshotMockFs.test.ts](#r0s128)|1:white_check_mark:|||883ms|
+|[e2e/__tests__/snapshotResolver.test.ts](#r0s129)|1:white_check_mark:|||823ms|
+|[e2e/__tests__/snapshotSerializers.test.ts](#r0s130)|2:white_check_mark:|||2s|
+|[e2e/__tests__/stackTrace.test.ts](#r0s131)|7:white_check_mark:|||5s|
+|[e2e/__tests__/stackTraceNoCaptureStackTrace.test.ts](#r0s132)|1:white_check_mark:|||899ms|
+|[e2e/__tests__/stackTraceSourceMaps.test.ts](#r0s133)|1:white_check_mark:|||2s|
+|[e2e/__tests__/stackTraceSourceMapsWithCoverage.test.ts](#r0s134)|1:white_check_mark:|||2s|
+|[e2e/__tests__/supportsDashedArgs.ts](#r0s135)|2:white_check_mark:|||968ms|
+|[e2e/__tests__/symbol.test.ts](#r0s136)|1:white_check_mark:|||49ms|
+|[e2e/__tests__/testEnvironment.test.ts](#r0s137)|1:white_check_mark:|||2s|
+|[e2e/__tests__/testEnvironmentAsync.test.ts](#r0s138)|1:white_check_mark:|||1s|
+|[e2e/__tests__/testEnvironmentCircus.test.ts](#r0s139)|1:white_check_mark:|||2s|
+|[e2e/__tests__/testEnvironmentCircusAsync.test.ts](#r0s140)|1:white_check_mark:|||2s|
+|[e2e/__tests__/testFailureExitCode.test.ts](#r0s141)|2:white_check_mark:|||4s|
+|[e2e/__tests__/testInRoot.test.ts](#r0s142)|1:white_check_mark:|||1s|
+|[e2e/__tests__/testNamePattern.test.ts](#r0s143)|1:white_check_mark:|||859ms|
+|[e2e/__tests__/testNamePatternSkipped.test.ts](#r0s144)|1:white_check_mark:|||991ms|
+|[e2e/__tests__/testPathPatternReporterMessage.test.ts](#r0s145)|1:white_check_mark:|||3s|
+|[e2e/__tests__/testResultsProcessor.test.ts](#r0s146)|1:white_check_mark:|||910ms|
+|[e2e/__tests__/testRetries.test.ts](#r0s147)|4:white_check_mark:|||3s|
+|[e2e/__tests__/testTodo.test.ts](#r0s148)|5:white_check_mark:|||4s|
+|[e2e/__tests__/timeouts.test.ts](#r0s149)|4:white_check_mark:|||4s|
+|[e2e/__tests__/timeoutsLegacy.test.ts](#r0s150)|1:white_check_mark:||3:warning:|71ms|
+|[e2e/__tests__/timerResetMocks.test.ts](#r0s151)|2:white_check_mark:|||2s|
+|[e2e/__tests__/timerUseRealTimers.test.ts](#r0s152)|1:white_check_mark:|||1s|
+|[e2e/__tests__/toMatchInlineSnapshot.test.ts](#r0s153)|12:white_check_mark:|||24s|
+|[e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts](#r0s154)|3:white_check_mark:|||5s|
+|[e2e/__tests__/toMatchSnapshot.test.ts](#r0s155)|9:white_check_mark:|||17s|
+|[e2e/__tests__/toMatchSnapshotWithRetries.test.ts](#r0s156)|2:white_check_mark:|||4s|
+|[e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts](#r0s157)|3:white_check_mark:|||4s|
+|[e2e/__tests__/toThrowErrorMatchingInlineSnapshot.test.ts](#r0s158)|4:white_check_mark:|||4s|
+|[e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts](#r0s159)|5:white_check_mark:|||4s|
+|[e2e/__tests__/transform.test.ts](#r0s160)|16:white_check_mark:|||27s|
+|[e2e/__tests__/transformLinkedModules.test.ts](#r0s161)|1:white_check_mark:|||783ms|
+|[e2e/__tests__/typescriptCoverage.test.ts](#r0s162)|1:white_check_mark:|||3s|
+|[e2e/__tests__/unexpectedToken.test.ts](#r0s163)|3:white_check_mark:|||3s|
+|[e2e/__tests__/useStderr.test.ts](#r0s164)|1:white_check_mark:|||1s|
+|[e2e/__tests__/v8Coverage.test.ts](#r0s165)|2:white_check_mark:|||2s|
+|[e2e/__tests__/verbose.test.ts](#r0s166)|1:white_check_mark:|||683ms|
+|[e2e/__tests__/version.test.ts](#r0s167)|1:white_check_mark:|||138ms|
+|[e2e/__tests__/watchModeNoAccess.test.ts](#r0s168)|1:white_check_mark:|||4s|
+|[e2e/__tests__/watchModeOnlyFailed.test.ts](#r0s169)|1:white_check_mark:|||1s|
+|[e2e/__tests__/watchModePatterns.test.ts](#r0s170)|2:white_check_mark:|||4s|
+|[e2e/__tests__/watchModeUpdateSnapshot.test.ts](#r0s171)|1:white_check_mark:|||1s|
+|[e2e/__tests__/workerForceExit.test.ts](#r0s172)|2:white_check_mark:|||5s|
+|[e2e/__tests__/wrongEnv.test.ts](#r0s173)|5:white_check_mark:|||4s|
+|[e2e/custom-test-sequencer/a.test.js](#r0s174)|1:white_check_mark:|||29ms|
+|[e2e/custom-test-sequencer/b.test.js](#r0s175)|1:white_check_mark:|||21ms|
+|[e2e/custom-test-sequencer/c.test.js](#r0s176)|1:white_check_mark:|||42ms|
+|[e2e/custom-test-sequencer/d.test.js](#r0s177)|1:white_check_mark:|||21ms|
+|[e2e/custom-test-sequencer/e.test.js](#r0s178)|1:white_check_mark:|||27ms|
+|[e2e/test-in-root/spec.js](#r0s179)|1:white_check_mark:|||19ms|
+|[e2e/test-in-root/test.js](#r0s180)|1:white_check_mark:|||37ms|
+|[e2e/timer-reset-mocks/after-reset-all-mocks/timerAndMock.test.js](#r0s181)|2:white_check_mark:|||30ms|
+|[e2e/timer-reset-mocks/with-reset-mocks/timerWithMock.test.js](#r0s182)|1:white_check_mark:|||34ms|
+|[e2e/v8-coverage/empty-sourcemap/test.ts](#r0s183)|1:white_check_mark:|||31ms|
+|[examples/angular/app.component.spec.ts](#r0s184)|3:white_check_mark:|||654ms|
+|[examples/angular/shared/data.service.spec.ts](#r0s185)|2:white_check_mark:|||431ms|
+|[examples/angular/shared/sub.service.spec.ts](#r0s186)|1:white_check_mark:|||109ms|
+|[examples/async/__tests__/user.test.js](#r0s187)|8:white_check_mark:|||96ms|
+|[examples/automatic-mocks/__tests__/automock.test.js](#r0s188)|2:white_check_mark:|||74ms|
+|[examples/automatic-mocks/__tests__/createMockFromModule.test.js](#r0s189)|2:white_check_mark:|||115ms|
+|[examples/automatic-mocks/__tests__/disableAutomocking.test.js](#r0s190)|1:white_check_mark:|||24ms|
+|[examples/enzyme/__tests__/CheckboxWithLabel-test.js](#r0s191)|1:white_check_mark:|||434ms|
+|[examples/getting-started/sum.test.js](#r0s192)|1:white_check_mark:|||78ms|
+|[examples/jquery/__tests__/display_user.test.js](#r0s193)|1:white_check_mark:|||196ms|
+|[examples/jquery/__tests__/fetch_current_user.test.js](#r0s194)|2:white_check_mark:|||196ms|
+|[examples/manual-mocks/__tests__/file_summarizer.test.js](#r0s195)|1:white_check_mark:|||87ms|
+|[examples/manual-mocks/__tests__/lodashMocking.test.js](#r0s196)|1:white_check_mark:|||109ms|
+|[examples/manual-mocks/__tests__/user.test.js](#r0s197)|1:white_check_mark:|||41ms|
+|[examples/manual-mocks/__tests__/userMocked.test.js](#r0s198)|1:white_check_mark:|||105ms|
+|[examples/module-mock/__tests__/full_mock.js](#r0s199)|1:white_check_mark:|||60ms|
+|[examples/module-mock/__tests__/mock_per_test.js](#r0s200)|2:white_check_mark:|||116ms|
+|[examples/module-mock/__tests__/partial_mock.js](#r0s201)|1:white_check_mark:|||215ms|
+|[examples/mongodb/__test__/db.test.js](#r0s202)|1:white_check_mark:|||236ms|
+|[examples/react-native/__tests__/intro.test.js](#r0s203)|4:white_check_mark:|||9s|
+|[examples/react-testing-library/__tests__/CheckboxWithLabel-test.js](#r0s204)|1:white_check_mark:|||469ms|
+|[examples/react/__tests__/CheckboxWithLabel-test.js](#r0s205)|1:white_check_mark:|||256ms|
+|[examples/snapshot/__tests__/clock.react.test.js](#r0s206)|1:white_check_mark:|||62ms|
+|[examples/snapshot/__tests__/link.react.test.js](#r0s207)|4:white_check_mark:|||181ms|
+|[examples/timer/__tests__/infinite_timer_game.test.js](#r0s208)|1:white_check_mark:|||94ms|
+|[examples/timer/__tests__/timer_game.test.js](#r0s209)|3:white_check_mark:|||74ms|
+|[examples/typescript/__tests__/calc.test.ts](#r0s210)|6:white_check_mark:|||276ms|
+|[examples/typescript/__tests__/CheckboxWithLabel-test.tsx](#r0s211)|1:white_check_mark:|||227ms|
+|[examples/typescript/__tests__/sub-test.ts](#r0s212)|1:white_check_mark:|||43ms|
+|[examples/typescript/__tests__/sum-test.ts](#r0s213)|2:white_check_mark:|||69ms|
+|[examples/typescript/__tests__/sum.test.js](#r0s214)|2:white_check_mark:|||100ms|
+|[packages/babel-jest/src/__tests__/index.ts](#r0s215)|6:white_check_mark:|||371ms|
+|[packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts](#r0s216)|4:white_check_mark:|||347ms|
+|[packages/diff-sequences/src/__tests__/index.property.test.ts](#r0s217)|7:white_check_mark:|||357ms|
+|[packages/diff-sequences/src/__tests__/index.test.ts](#r0s218)|48:white_check_mark:|||195ms|
+|[packages/expect/src/__tests__/assertionCounts.test.ts](#r0s219)|6:white_check_mark:|||60ms|
+|[packages/expect/src/__tests__/asymmetricMatchers.test.ts](#r0s220)|38:white_check_mark:|||207ms|
+|[packages/expect/src/__tests__/extend.test.ts](#r0s221)|10:white_check_mark:|||99ms|
+|[packages/expect/src/__tests__/isError.test.ts](#r0s222)|4:white_check_mark:|||43ms|
+|[packages/expect/src/__tests__/matchers-toContain.property.test.ts](#r0s223)|2:white_check_mark:|||236ms|
+|[packages/expect/src/__tests__/matchers-toContainEqual.property.test.ts](#r0s224)|2:white_check_mark:|||287ms|
+|[packages/expect/src/__tests__/matchers-toEqual.property.test.ts](#r0s225)|2:white_check_mark:|||1s|
+|[packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts](#r0s226)|3:white_check_mark:|||394ms|
+|[packages/expect/src/__tests__/matchers.test.js](#r0s227)|592:white_check_mark:|||862ms|
+|[packages/expect/src/__tests__/spyMatchers.test.ts](#r0s228)|248:white_check_mark:|||395ms|
+|[packages/expect/src/__tests__/stacktrace.test.ts](#r0s229)|3:white_check_mark:|||69ms|
+|[packages/expect/src/__tests__/symbolInObjects.test.ts](#r0s230)|3:white_check_mark:|||33ms|
+|[packages/expect/src/__tests__/toEqual-dom.test.ts](#r0s231)|12:white_check_mark:|||99ms|
+|[packages/expect/src/__tests__/toThrowMatchers.test.ts](#r0s232)|98:white_check_mark:|||257ms|
+|[packages/expect/src/__tests__/utils.test.ts](#r0s233)|41:white_check_mark:|||147ms|
+|[packages/jest-circus/src/__tests__/afterAll.test.ts](#r0s234)|6:white_check_mark:|||6s|
+|[packages/jest-circus/src/__tests__/baseTest.test.ts](#r0s235)|2:white_check_mark:|||3s|
+|[packages/jest-circus/src/__tests__/circusItTestError.test.ts](#r0s236)|8:white_check_mark:|||300ms|
+|[packages/jest-circus/src/__tests__/circusItTodoTestError.test.ts](#r0s237)|3:white_check_mark:|||81ms|
+|[packages/jest-circus/src/__tests__/hooks.test.ts](#r0s238)|3:white_check_mark:|||4s|
+|[packages/jest-circus/src/__tests__/hooksError.test.ts](#r0s239)|32:white_check_mark:|||127ms|
+|[packages/jest-cli/src/__tests__/cli/args.test.ts](#r0s240)|17:white_check_mark:|||345ms|
+|[packages/jest-cli/src/init/__tests__/init.test.js](#r0s241)|24:white_check_mark:|||119ms|
+|[packages/jest-cli/src/init/__tests__/modifyPackageJson.test.ts](#r0s242)|4:white_check_mark:|||30ms|
+|[packages/jest-config/src/__tests__/Defaults.test.ts](#r0s243)|1:white_check_mark:|||672ms|
+|[packages/jest-config/src/__tests__/getMaxWorkers.test.ts](#r0s244)|7:white_check_mark:|||67ms|
+|[packages/jest-config/src/__tests__/normalize.test.js](#r0s245)|118:white_check_mark:|||798ms|
+|[packages/jest-config/src/__tests__/readConfig.test.ts](#r0s246)|1:white_check_mark:|||76ms|
+|[packages/jest-config/src/__tests__/readConfigs.test.ts](#r0s247)|3:white_check_mark:|||135ms|
+|[packages/jest-config/src/__tests__/resolveConfigPath.test.ts](#r0s248)|10:white_check_mark:|||183ms|
+|[packages/jest-config/src/__tests__/setFromArgv.test.ts](#r0s249)|4:white_check_mark:|||53ms|
+|[packages/jest-config/src/__tests__/validatePattern.test.ts](#r0s250)|4:white_check_mark:|||52ms|
+|[packages/jest-console/src/__tests__/bufferedConsole.test.ts](#r0s251)|20:white_check_mark:|||171ms|
+|[packages/jest-console/src/__tests__/CustomConsole.test.ts](#r0s252)|23:white_check_mark:|||115ms|
+|[packages/jest-console/src/__tests__/getConsoleOutput.test.ts](#r0s253)|12:white_check_mark:|||56ms|
+|[packages/jest-core/src/__tests__/FailedTestsCache.test.js](#r0s254)|1:white_check_mark:|||25ms|
+|[packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js](#r0s255)|5:white_check_mark:|||61ms|
+|[packages/jest-core/src/__tests__/globals.test.ts](#r0s256)|1:white_check_mark:|||22ms|
+|[packages/jest-core/src/__tests__/runJest.test.js](#r0s257)|2:white_check_mark:|||261ms|
+|[packages/jest-core/src/__tests__/SearchSource.test.ts](#r0s258)|27:white_check_mark:|||3s|
+|[packages/jest-core/src/__tests__/SnapshotInteractiveMode.test.js](#r0s259)|13:white_check_mark:|||89ms|
+|[packages/jest-core/src/__tests__/TestScheduler.test.js](#r0s260)|8:white_check_mark:|||520ms|
+|[packages/jest-core/src/__tests__/testSchedulerHelper.test.js](#r0s261)|12:white_check_mark:|||48ms|
+|[packages/jest-core/src/__tests__/watch.test.js](#r0s262)|80:white_check_mark:|||7s|
+|[packages/jest-core/src/__tests__/watchFileChanges.test.ts](#r0s263)|1:white_check_mark:|||2s|
+|[packages/jest-core/src/__tests__/watchFilenamePatternMode.test.js](#r0s264)|2:white_check_mark:|||165ms|
+|[packages/jest-core/src/__tests__/watchTestNamePatternMode.test.js](#r0s265)|1:white_check_mark:|||246ms|
+|[packages/jest-core/src/lib/__tests__/isValidPath.test.ts](#r0s266)|3:white_check_mark:|||166ms|
+|[packages/jest-core/src/lib/__tests__/logDebugMessages.test.ts](#r0s267)|3:white_check_mark:|||48ms|
+|[packages/jest-create-cache-key-function/src/__tests__/index.test.ts](#r0s268)|1:white_check_mark:|||75ms|
+|[packages/jest-diff/src/__tests__/diff.test.ts](#r0s269)|107:white_check_mark:|||625ms|
+|[packages/jest-diff/src/__tests__/diffStringsRaw.test.ts](#r0s270)|2:white_check_mark:|||55ms|
+|[packages/jest-diff/src/__tests__/getAlignedDiffs.test.ts](#r0s271)|24:white_check_mark:|||72ms|
+|[packages/jest-diff/src/__tests__/joinAlignedDiffs.test.ts](#r0s272)|6:white_check_mark:|||44ms|
+|[packages/jest-docblock/src/__tests__/index.test.ts](#r0s273)|36:white_check_mark:|||177ms|
+|[packages/jest-each/src/__tests__/array.test.ts](#r0s274)|159:white_check_mark:|||192ms|
+|[packages/jest-each/src/__tests__/index.test.ts](#r0s275)|10:white_check_mark:|||44ms|
+|[packages/jest-each/src/__tests__/template.test.ts](#r0s276)|242:white_check_mark:|||483ms|
+|[packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts](#r0s277)|2:white_check_mark:|||783ms|
+|[packages/jest-environment-node/src/__tests__/node_environment.test.ts](#r0s278)|6:white_check_mark:|||184ms|
+|[packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts](#r0s279)|50:white_check_mark:|||302ms|
+|[packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts](#r0s280)|40:white_check_mark:|||317ms|
+|[packages/jest-get-type/src/__tests__/getType.test.ts](#r0s281)|14:white_check_mark:|||45ms|
+|[packages/jest-get-type/src/__tests__/isPrimitive.test.ts](#r0s282)|18:white_check_mark:|||36ms|
+|[packages/jest-globals/src/__tests__/index.ts](#r0s283)|1:white_check_mark:|||533ms|
+|[packages/jest-haste-map/src/__tests__/get_mock_name.test.js](#r0s284)|1:white_check_mark:|||22ms|
+|[packages/jest-haste-map/src/__tests__/includes_dotfiles.test.ts](#r0s285)|1:white_check_mark:|||337ms|
+|[packages/jest-haste-map/src/__tests__/index.test.js](#r0s286)|44:white_check_mark:|||1s|
+|[packages/jest-haste-map/src/__tests__/worker.test.js](#r0s287)|7:white_check_mark:|||100ms|
+|[packages/jest-haste-map/src/crawlers/__tests__/node.test.js](#r0s288)|10:white_check_mark:|||170ms|
+|[packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js](#r0s289)|8:white_check_mark:|||153ms|
+|[packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js](#r0s290)|15:white_check_mark:|||56ms|
+|[packages/jest-haste-map/src/lib/__tests__/fast_path.test.js](#r0s291)|5:white_check_mark:|||29ms|
+|[packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js](#r0s292)|1:white_check_mark:|||35ms|
+|[packages/jest-haste-map/src/lib/__tests__/isRegExpSupported.test.js](#r0s293)|2:white_check_mark:|||31ms|
+|[packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js](#r0s294)|2:white_check_mark:|||35ms|
+|[packages/jest-jasmine2/src/__tests__/concurrent.test.ts](#r0s295)|3:white_check_mark:|||24ms|
+|[packages/jest-jasmine2/src/__tests__/expectationResultFactory.test.ts](#r0s296)|7:white_check_mark:|||70ms|
+|[packages/jest-jasmine2/src/__tests__/hooksError.test.ts](#r0s297)|32:white_check_mark:|||51ms|
+|[packages/jest-jasmine2/src/__tests__/iterators.test.ts](#r0s298)|4:white_check_mark:|||43ms|
+|[packages/jest-jasmine2/src/__tests__/itTestError.test.ts](#r0s299)|6:white_check_mark:|||32ms|
+|[packages/jest-jasmine2/src/__tests__/itToTestAlias.test.ts](#r0s300)|1:white_check_mark:|||23ms|
+|[packages/jest-jasmine2/src/__tests__/pTimeout.test.ts](#r0s301)|3:white_check_mark:|||44ms|
+|[packages/jest-jasmine2/src/__tests__/queueRunner.test.ts](#r0s302)|6:white_check_mark:|||93ms|
+|[packages/jest-jasmine2/src/__tests__/reporter.test.ts](#r0s303)|1:white_check_mark:|||107ms|
+|[packages/jest-jasmine2/src/__tests__/Suite.test.ts](#r0s304)|1:white_check_mark:|||84ms|
+|[packages/jest-jasmine2/src/__tests__/todoError.test.ts](#r0s305)|3:white_check_mark:|||27ms|
+|[packages/jest-leak-detector/src/__tests__/index.test.ts](#r0s306)|6:white_check_mark:|||986ms|
+|[packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts](#r0s307)|11:white_check_mark:|||49ms|
+|[packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceableDom.test.ts](#r0s308)|2:white_check_mark:|||48ms|
+|[packages/jest-matcher-utils/src/__tests__/index.test.ts](#r0s309)|48:white_check_mark:|||391ms|
+|[packages/jest-matcher-utils/src/__tests__/printDiffOrStringify.test.ts](#r0s310)|21:white_check_mark:|||114ms|
+|[packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts](#r0s311)|17:white_check_mark:|||111ms|
+|[packages/jest-message-util/src/__tests__/messages.test.ts](#r0s312)|11:white_check_mark:|||205ms|
+|[packages/jest-mock/src/__tests__/index.test.ts](#r0s313)|84:white_check_mark:|||509ms|
+|[packages/jest-regex-util/src/__tests__/index.test.ts](#r0s314)|8:white_check_mark:|||56ms|
+|[packages/jest-repl/src/__tests__/jest_repl.test.js](#r0s315)|1:white_check_mark:|||1s|
+|[packages/jest-repl/src/__tests__/runtime_cli.test.js](#r0s316)|4:white_check_mark:|||4s|
+|[packages/jest-reporters/src/__tests__/CoverageReporter.test.js](#r0s317)|12:white_check_mark:|||397ms|
+|[packages/jest-reporters/src/__tests__/CoverageWorker.test.js](#r0s318)|2:white_check_mark:|||199ms|
+|[packages/jest-reporters/src/__tests__/DefaultReporter.test.js](#r0s319)|2:white_check_mark:|||148ms|
+|[packages/jest-reporters/src/__tests__/generateEmptyCoverage.test.js](#r0s320)|3:white_check_mark:|||1s|
+|[packages/jest-reporters/src/__tests__/getResultHeader.test.js](#r0s321)|4:white_check_mark:|||30ms|
+|[packages/jest-reporters/src/__tests__/getSnapshotStatus.test.js](#r0s322)|3:white_check_mark:|||28ms|
+|[packages/jest-reporters/src/__tests__/getSnapshotSummary.test.js](#r0s323)|4:white_check_mark:|||49ms|
+|[packages/jest-reporters/src/__tests__/getWatermarks.test.ts](#r0s324)|2:white_check_mark:|||37ms|
+|[packages/jest-reporters/src/__tests__/NotifyReporter.test.ts](#r0s325)|18:white_check_mark:|||166ms|
+|[packages/jest-reporters/src/__tests__/SummaryReporter.test.js](#r0s326)|4:white_check_mark:|||366ms|
+|[packages/jest-reporters/src/__tests__/utils.test.ts](#r0s327)|10:white_check_mark:|||85ms|
+|[packages/jest-reporters/src/__tests__/VerboseReporter.test.js](#r0s328)|11:white_check_mark:|||425ms|
+|[packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts](#r0s329)|11:white_check_mark:|||666ms|
+|[packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts](#r0s330)|4:white_check_mark:|||36ms|
+|[packages/jest-resolve/src/__tests__/resolve.test.ts](#r0s331)|16:white_check_mark:|||1s|
+|[packages/jest-runner/src/__tests__/testRunner.test.ts](#r0s332)|2:white_check_mark:|||905ms|
+|[packages/jest-runtime/src/__tests__/instrumentation.test.ts](#r0s333)|1:white_check_mark:|||275ms|
+|[packages/jest-runtime/src/__tests__/runtime_create_mock_from_module.test.js](#r0s334)|3:white_check_mark:|||606ms|
+|[packages/jest-runtime/src/__tests__/runtime_environment.test.js](#r0s335)|2:white_check_mark:|||497ms|
+|[packages/jest-runtime/src/__tests__/runtime_internal_module.test.js](#r0s336)|4:white_check_mark:|||727ms|
+|[packages/jest-runtime/src/__tests__/runtime_jest_fn.js](#r0s337)|4:white_check_mark:|||479ms|
+|[packages/jest-runtime/src/__tests__/runtime_jest_spy_on.test.js](#r0s338)|2:white_check_mark:|||521ms|
+|[packages/jest-runtime/src/__tests__/runtime_mock.test.js](#r0s339)|4:white_check_mark:|||743ms|
+|[packages/jest-runtime/src/__tests__/runtime_module_directories.test.js](#r0s340)|4:white_check_mark:|||525ms|
+|[packages/jest-runtime/src/__tests__/runtime_node_path.test.js](#r0s341)|4:white_check_mark:|||1s|
+|[packages/jest-runtime/src/__tests__/runtime_require_actual.test.js](#r0s342)|2:white_check_mark:|||478ms|
+|[packages/jest-runtime/src/__tests__/runtime_require_cache.test.js](#r0s343)|2:white_check_mark:|||454ms|
+|[packages/jest-runtime/src/__tests__/runtime_require_mock.test.js](#r0s344)|13:white_check_mark:|||962ms|
+|[packages/jest-runtime/src/__tests__/runtime_require_module_no_ext.test.js](#r0s345)|1:white_check_mark:|||261ms|
+|[packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js](#r0s346)|6:white_check_mark:|||2s|
+|[packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js](#r0s347)|17:white_check_mark:|||1s|
+|[packages/jest-runtime/src/__tests__/runtime_require_module.test.js](#r0s348)|27:white_check_mark:|||2s|
+|[packages/jest-runtime/src/__tests__/runtime_require_resolve.test.ts](#r0s349)|5:white_check_mark:|||707ms|
+|[packages/jest-runtime/src/__tests__/runtime_wrap.js](#r0s350)|2:white_check_mark:|||263ms|
+|[packages/jest-runtime/src/__tests__/Runtime-sourceMaps.test.js](#r0s351)|1:white_check_mark:|||584ms|
+|[packages/jest-runtime/src/__tests__/Runtime-statics.test.js](#r0s352)|2:white_check_mark:|||162ms|
+|[packages/jest-serializer/src/__tests__/index.test.ts](#r0s353)|17:white_check_mark:|||158ms|
+|[packages/jest-snapshot/src/__tests__/dedentLines.test.ts](#r0s354)|17:white_check_mark:|||94ms|
+|[packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts](#r0s355)|22:white_check_mark:|||1s|
+|[packages/jest-snapshot/src/__tests__/matcher.test.ts](#r0s356)|1:white_check_mark:|||131ms|
+|[packages/jest-snapshot/src/__tests__/mockSerializer.test.ts](#r0s357)|10:white_check_mark:|||45ms|
+|[packages/jest-snapshot/src/__tests__/printSnapshot.test.ts](#r0s358)|71:white_check_mark:|||1s|
+|[packages/jest-snapshot/src/__tests__/SnapshotResolver.test.ts](#r0s359)|10:white_check_mark:|||98ms|
+|[packages/jest-snapshot/src/__tests__/throwMatcher.test.ts](#r0s360)|3:white_check_mark:|||481ms|
+|[packages/jest-snapshot/src/__tests__/utils.test.ts](#r0s361)|26:white_check_mark:|||214ms|
+|[packages/jest-source-map/src/__tests__/getCallsite.test.ts](#r0s362)|3:white_check_mark:|||86ms|
+|[packages/jest-test-result/src/__tests__/formatTestResults.test.ts](#r0s363)|1:white_check_mark:|||53ms|
+|[packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js](#r0s364)|8:white_check_mark:|||251ms|
+|[packages/jest-transform/src/__tests__/ScriptTransformer.test.ts](#r0s365)|22:white_check_mark:|||2s|
+|[packages/jest-transform/src/__tests__/shouldInstrument.test.ts](#r0s366)|25:white_check_mark:|||155ms|
+|[packages/jest-util/src/__tests__/createProcessObject.test.ts](#r0s367)|4:white_check_mark:|||81ms|
+|[packages/jest-util/src/__tests__/deepCyclicCopy.test.ts](#r0s368)|12:white_check_mark:|||86ms|
+|[packages/jest-util/src/__tests__/errorWithStack.test.ts](#r0s369)|1:white_check_mark:|||41ms|
+|[packages/jest-util/src/__tests__/formatTime.test.ts](#r0s370)|11:white_check_mark:|||82ms|
+|[packages/jest-util/src/__tests__/globsToMatcher.test.ts](#r0s371)|4:white_check_mark:|||56ms|
+|[packages/jest-util/src/__tests__/installCommonGlobals.test.ts](#r0s372)|2:white_check_mark:|||68ms|
+|[packages/jest-util/src/__tests__/isInteractive.test.ts](#r0s373)|2:white_check_mark:|||35ms|
+|[packages/jest-util/src/__tests__/isPromise.test.ts](#r0s374)|10:white_check_mark:|||30ms|
+|[packages/jest-validate/src/__tests__/validate.test.ts](#r0s375)|23:white_check_mark:|||283ms|
+|[packages/jest-validate/src/__tests__/validateCLIOptions.test.js](#r0s376)|6:white_check_mark:|||83ms|
+|[packages/jest-watcher/src/lib/__tests__/formatTestNameByPattern.test.ts](#r0s377)|11:white_check_mark:|||129ms|
+|[packages/jest-watcher/src/lib/__tests__/prompt.test.ts](#r0s378)|3:white_check_mark:|||91ms|
+|[packages/jest-watcher/src/lib/__tests__/scroll.test.ts](#r0s379)|5:white_check_mark:|||57ms|
+|[packages/jest-worker/src/__tests__/Farm.test.js](#r0s380)|10:white_check_mark:|||158ms|
+|[packages/jest-worker/src/__tests__/FifoQueue.test.js](#r0s381)|3:white_check_mark:|||48ms|
+|[packages/jest-worker/src/__tests__/index.test.js](#r0s382)|8:white_check_mark:|||230ms|
+|[packages/jest-worker/src/__tests__/PriorityQueue.test.js](#r0s383)|5:white_check_mark:|||63ms|
+|[packages/jest-worker/src/__tests__/process-integration.test.js](#r0s384)|5:white_check_mark:|||62ms|
+|[packages/jest-worker/src/__tests__/thread-integration.test.js](#r0s385)|6:white_check_mark:|||114ms|
+|[packages/jest-worker/src/__tests__/WorkerPool.test.js](#r0s386)|3:white_check_mark:|||51ms|
+|[packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js](#r0s387)|11:white_check_mark:|||653ms|
+|[packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js](#r0s388)|17:white_check_mark:|||184ms|
+|[packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js](#r0s389)|15:white_check_mark:|||258ms|
+|[packages/jest-worker/src/workers/__tests__/processChild.test.js](#r0s390)|10:white_check_mark:|||135ms|
+|[packages/jest-worker/src/workers/__tests__/threadChild.test.js](#r0s391)|10:white_check_mark:|||120ms|
+|[packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts](#r0s392)|38:white_check_mark:|||137ms|
+|[packages/pretty-format/src/__tests__/ConvertAnsi.test.ts](#r0s393)|6:white_check_mark:|||43ms|
+|[packages/pretty-format/src/__tests__/DOMCollection.test.ts](#r0s394)|10:white_check_mark:|||64ms|
+|[packages/pretty-format/src/__tests__/DOMElement.test.ts](#r0s395)|28:white_check_mark:|||148ms|
+|[packages/pretty-format/src/__tests__/Immutable.test.ts](#r0s396)|111:white_check_mark:|||443ms|
+|[packages/pretty-format/src/__tests__/prettyFormat.test.ts](#r0s397)|86:white_check_mark:|||219ms|
+|[packages/pretty-format/src/__tests__/react.test.tsx](#r0s398)|55:white_check_mark:|||325ms|
+|[packages/pretty-format/src/__tests__/ReactElement.test.ts](#r0s399)|3:white_check_mark:|||64ms|
+### :white_check_mark: <a id="user-content-r0s0" href="#r0s0">e2e/__tests__/asyncAndCallback.test.ts</a>
+```
+:white_check_mark: errors when a test both returns a promise and takes a callback
+```
+### :white_check_mark: <a id="user-content-r0s1" href="#r0s1">e2e/__tests__/asyncRegenerator.test.ts</a>
+```
+:white_check_mark: successfully transpiles async
+```
+### :white_check_mark: <a id="user-content-r0s2" href="#r0s2">e2e/__tests__/autoClearMocks.test.ts</a>
+```
+:white_check_mark: suite with auto-clear
+:white_check_mark: suite without auto-clear
+```
+### :white_check_mark: <a id="user-content-r0s3" href="#r0s3">e2e/__tests__/autoResetMocks.test.ts</a>
+```
+:white_check_mark: suite with auto-reset
+:white_check_mark: suite without auto-reset
+```
+### :white_check_mark: <a id="user-content-r0s4" href="#r0s4">e2e/__tests__/autoRestoreMocks.test.ts</a>
+```
+:white_check_mark: suite with auto-restore
+:white_check_mark: suite without auto-restore
+```
+### :white_check_mark: <a id="user-content-r0s5" href="#r0s5">e2e/__tests__/babelPluginJestHoist.test.ts</a>
+```
+:white_check_mark: successfully runs the tests inside `babel-plugin-jest-hoist/`
+```
+### :white_check_mark: <a id="user-content-r0s6" href="#r0s6">e2e/__tests__/badSourceMap.test.ts</a>
+```
+:white_check_mark: suite with test cases that contain malformed sourcemaps
+```
+### :white_check_mark: <a id="user-content-r0s7" href="#r0s7">e2e/__tests__/beforeAllFiltered.ts</a>
+```
+Correct BeforeAll run
+  :white_check_mark: ensures the BeforeAll of ignored suite is not run
+```
+### :white_check_mark: <a id="user-content-r0s8" href="#r0s8">e2e/__tests__/beforeEachQueue.ts</a>
+```
+:white_check_mark: does not work on jest-circus
+Correct beforeEach order
+  :warning: ensures the correct order for beforeEach
+```
+### :white_check_mark: <a id="user-content-r0s9" href="#r0s9">e2e/__tests__/callDoneTwice.test.ts</a>
+```
+:white_check_mark: `done()` should not be called more than once
+```
+### :white_check_mark: <a id="user-content-r0s10" href="#r0s10">e2e/__tests__/chaiAssertionLibrary.ts</a>
+```
+:white_check_mark: chai assertion errors should display properly
+```
+### :white_check_mark: <a id="user-content-r0s11" href="#r0s11">e2e/__tests__/circularInequality.test.ts</a>
+```
+:white_check_mark: handles circular inequality properly
+```
+### :white_check_mark: <a id="user-content-r0s12" href="#r0s12">e2e/__tests__/circusConcurrentEach.test.ts</a>
+```
+:white_check_mark: works with concurrent.each
+:white_check_mark: works with concurrent.only.each
+```
+### :white_check_mark: <a id="user-content-r0s13" href="#r0s13">e2e/__tests__/circusDeclarationErrors.test.ts</a>
+```
+:white_check_mark: defining tests and hooks asynchronously throws
+```
+### :white_check_mark: <a id="user-content-r0s14" href="#r0s14">e2e/__tests__/clearCache.test.ts</a>
+```
+jest --clearCache
+  :white_check_mark: normal run results in cache directory being written
+  :white_check_mark: clearCache results in deleted directory and exitCode 0
+```
+### :white_check_mark: <a id="user-content-r0s15" href="#r0s15">e2e/__tests__/cliHandlesExactFilenames.test.ts</a>
+```
+:white_check_mark: CLI accepts exact file names if matchers matched
+:white_check_mark: CLI skips exact file names if no matchers matched
+```
+### :white_check_mark: <a id="user-content-r0s16" href="#r0s16">e2e/__tests__/compareDomNodes.test.ts</a>
+```
+:white_check_mark: does not crash when expect involving a DOM node fails
+```
+### :white_check_mark: <a id="user-content-r0s17" href="#r0s17">e2e/__tests__/config.test.ts</a>
+```
+:white_check_mark: config as JSON
+:white_check_mark: works with sane config JSON
+:white_check_mark: watchman config option is respected over default argv
+:white_check_mark: config from argv is respected with sane config JSON
+:white_check_mark: works with jsdom testEnvironmentOptions config JSON
+:white_check_mark: negated flags override previous flags
+```
+### :white_check_mark: <a id="user-content-r0s18" href="#r0s18">e2e/__tests__/console.test.ts</a>
+```
+:white_check_mark: console printing
+:white_check_mark: console printing with --verbose
+:white_check_mark: does not print to console with --silent
+:white_check_mark: respects --noStackTrace
+:white_check_mark: respects noStackTrace in config
+:white_check_mark: the jsdom console is the same as the test console
+:white_check_mark: does not error out when using winston
+```
+### :white_check_mark: <a id="user-content-r0s19" href="#r0s19">e2e/__tests__/consoleAfterTeardown.test.ts</a>
+```
+:white_check_mark: console printing
+```
+### :white_check_mark: <a id="user-content-r0s20" href="#r0s20">e2e/__tests__/consoleLogOutputWhenRunInBand.test.ts</a>
+```
+:white_check_mark: prints console.logs when run with forceExit
+```
+### :white_check_mark: <a id="user-content-r0s21" href="#r0s21">e2e/__tests__/coverageHandlebars.test.ts</a>
+```
+:white_check_mark: code coverage for Handlebars
+```
+### :white_check_mark: <a id="user-content-r0s22" href="#r0s22">e2e/__tests__/coverageRemapping.test.ts</a>
+```
+:white_check_mark: maps code coverage against original source
+```
+### :white_check_mark: <a id="user-content-r0s23" href="#r0s23">e2e/__tests__/coverageReport.test.ts</a>
+```
+:white_check_mark: outputs coverage report
+:white_check_mark: collects coverage only from specified file
+:white_check_mark: collects coverage only from multiple specified files
+:white_check_mark: collects coverage only from specified files avoiding dependencies
+:white_check_mark: json reporter printing with --coverage
+:white_check_mark: outputs coverage report as json
+:white_check_mark: outputs coverage report when text is requested
+:white_check_mark: outputs coverage report when text-summary is requested
+:white_check_mark: outputs coverage report when text and text-summary is requested
+:white_check_mark: does not output coverage report when html is requested
+:white_check_mark: collects coverage from duplicate files avoiding shared cache
+:white_check_mark: generates coverage when using the testRegex config param
+```
+### :white_check_mark: <a id="user-content-r0s24" href="#r0s24">e2e/__tests__/coverageThreshold.test.ts</a>
+```
+:white_check_mark: exits with 1 if coverage threshold is not met
+:white_check_mark: exits with 1 if path threshold group is not found in coverage data
+:white_check_mark: exits with 0 if global threshold group is not found in coverage data
+:white_check_mark: excludes tests matched by path threshold groups from global group
+:white_check_mark: file is matched by all path and glob threshold groups
+```
+### :white_check_mark: <a id="user-content-r0s25" href="#r0s25">e2e/__tests__/coverageTransformInstrumented.test.ts</a>
+```
+:white_check_mark: code coverage for transform instrumented code
+```
+### :white_check_mark: <a id="user-content-r0s26" href="#r0s26">e2e/__tests__/coverageWithoutTransform.test.ts</a>
+```
+:white_check_mark: produces code coverage for uncovered files without transformer
+```
+### :white_check_mark: <a id="user-content-r0s27" href="#r0s27">e2e/__tests__/createProcessObject.test.ts</a>
+```
+:white_check_mark: allows retrieving the current domain
+```
+### :white_check_mark: <a id="user-content-r0s28" href="#r0s28">e2e/__tests__/customInlineSnapshotMatchers.test.ts</a>
+```
+:white_check_mark: works with custom inline snapshot matchers
+```
+### :white_check_mark: <a id="user-content-r0s29" href="#r0s29">e2e/__tests__/customMatcherStackTrace.test.ts</a>
+```
+:white_check_mark: works with custom matchers
+:white_check_mark: custom async matchers
+```
+### :white_check_mark: <a id="user-content-r0s30" href="#r0s30">e2e/__tests__/customReporters.test.ts</a>
+```
+Custom Reporters Integration
+  :white_check_mark: valid string format for adding reporters
+  :white_check_mark: valid array format for adding reporters
+  :white_check_mark: invalid format for adding reporters
+  :white_check_mark: default reporters enabled
+  :white_check_mark: TestReporter with all tests passing
+  :white_check_mark: TestReporter with all tests failing
+  :white_check_mark: IncompleteReporter for flexibility
+  :white_check_mark: reporters can be default exports
+  :white_check_mark: prints reporter errors
+```
+### :white_check_mark: <a id="user-content-r0s31" href="#r0s31">e2e/__tests__/customResolver.test.ts</a>
+```
+:white_check_mark: use the custom resolver
+```
+### :white_check_mark: <a id="user-content-r0s32" href="#r0s32">e2e/__tests__/customTestSequencers.test.ts</a>
+```
+:white_check_mark: run prioritySequence first sync
+:white_check_mark: run prioritySequence first async
+:white_check_mark: run failed tests async
+```
+### :white_check_mark: <a id="user-content-r0s33" href="#r0s33">e2e/__tests__/debug.test.ts</a>
+```
+jest --debug
+  :white_check_mark: outputs debugging info before running the test
+```
+### :white_check_mark: <a id="user-content-r0s34" href="#r0s34">e2e/__tests__/declarationErrors.test.ts</a>
+```
+:white_check_mark: errors if describe returns a Promise
+:white_check_mark: errors if describe returns something
+:white_check_mark: errors if describe throws
+```
+### :white_check_mark: <a id="user-content-r0s35" href="#r0s35">e2e/__tests__/dependencyClash.test.ts</a>
+```
+:white_check_mark: does not require project modules from inside node_modules
+```
+### :white_check_mark: <a id="user-content-r0s36" href="#r0s36">e2e/__tests__/detectOpenHandles.ts</a>
+```
+:white_check_mark: prints message about flag on slow tests
+:white_check_mark: prints message about flag on forceExit
+:white_check_mark: prints out info about open handlers
+:white_check_mark: does not report promises
+:white_check_mark: prints out info about open handlers from inside tests
+on node >=11.10.0
+  :white_check_mark: does not report ELD histograms
+notify
+  :white_check_mark: does not report --notify flag
+on node >=11
+  :white_check_mark: does not report timeouts using unref
+```
+### :white_check_mark: <a id="user-content-r0s37" href="#r0s37">e2e/__tests__/domDiffing.test.ts</a>
+```
+:white_check_mark: should work without error
+```
+### :white_check_mark: <a id="user-content-r0s38" href="#r0s38">e2e/__tests__/doneInHooks.test.ts</a>
+```
+:white_check_mark: `done()` works properly in hooks
+```
+### :white_check_mark: <a id="user-content-r0s39" href="#r0s39">e2e/__tests__/dynamicRequireDependencies.ts</a>
+```
+:white_check_mark: successfully runs tests with dynamic dependencies
+```
+### :white_check_mark: <a id="user-content-r0s40" href="#r0s40">e2e/__tests__/each.test.ts</a>
+```
+:white_check_mark: works with passing tests
+:white_check_mark: shows error message when not enough arguments are supplied to tests
+:white_check_mark: shows the correct errors in stderr when failing tests
+:white_check_mark: shows only the tests with .only as being ran
+:white_check_mark: shows only the tests without .skip as being ran
+:white_check_mark: runs only the describe.only.each tests
+:white_check_mark: formats args with pretty format when given %p
+```
+### :white_check_mark: <a id="user-content-r0s41" href="#r0s41">e2e/__tests__/emptyDescribeWithHooks.test.ts</a>
+```
+:white_check_mark: hook in empty describe
+:white_check_mark: hook in describe with skipped test
+:white_check_mark: hook in empty nested describe
+:white_check_mark: multiple hooks in empty describe
+```
+### :white_check_mark: <a id="user-content-r0s42" href="#r0s42">e2e/__tests__/emptySuiteError.test.ts</a>
+```
+JSON Reporter
+  :white_check_mark: fails the test suite if it contains no tests
+```
+### :white_check_mark: <a id="user-content-r0s43" href="#r0s43">e2e/__tests__/env.test.ts</a>
+```
+Environment override
+  :white_check_mark: uses jsdom when specified
+  :white_check_mark: uses node as default from package.json
+  :white_check_mark: uses node when specified
+  :white_check_mark: fails when the env is not available
+Environment equivalent
+  :white_check_mark: uses jsdom
+  :white_check_mark: uses node
+```
+### :white_check_mark: <a id="user-content-r0s44" href="#r0s44">e2e/__tests__/environmentAfterTeardown.test.ts</a>
+```
+:white_check_mark: prints useful error for environment methods after test is done
+```
+### :white_check_mark: <a id="user-content-r0s45" href="#r0s45">e2e/__tests__/errorOnDeprecated.test.ts</a>
+```
+:white_check_mark: does not work on jest-circus
+:warning: fail.test.js errors in errorOnDeprecated mode
+:warning: jasmine.addMatchers.test.js errors in errorOnDeprecated mode
+:warning: jasmine.any.test.js errors in errorOnDeprecated mode
+:warning: jasmine.anything.test.js errors in errorOnDeprecated mode
+:warning: jasmine.arrayContaining.test.js errors in errorOnDeprecated mode
+:warning: jasmine.createSpy.test.js errors in errorOnDeprecated mode
+:warning: jasmine.objectContaining.test.js errors in errorOnDeprecated mode
+:warning: jasmine.stringMatching.test.js errors in errorOnDeprecated mode
+:warning: pending.test.js errors in errorOnDeprecated mode
+:warning: spyOn.test.js errors in errorOnDeprecated mode
+:warning: spyOnProperty.test.js errors in errorOnDeprecated mode
+:warning: defaultTimeoutInterval.test.js errors in errorOnDeprecated mode
+:warning: fail.test.js errors when not in errorOnDeprecated mode
+:warning: jasmine.addMatchers.test.js passes when not in errorOnDeprecated mode
+:warning: jasmine.any.test.js passes when not in errorOnDeprecated mode
+:warning: jasmine.anything.test.js passes when not in errorOnDeprecated mode
+:warning: jasmine.arrayContaining.test.js passes when not in errorOnDeprecated mode
+:warning: jasmine.createSpy.test.js passes when not in errorOnDeprecated mode
+:warning: jasmine.objectContaining.test.js passes when not in errorOnDeprecated mode
+:warning: jasmine.stringMatching.test.js passes when not in errorOnDeprecated mode
+:warning: pending.test.js passes when not in errorOnDeprecated mode
+:warning: spyOn.test.js passes when not in errorOnDeprecated mode
+:warning: spyOnProperty.test.js errors when not in errorOnDeprecated mode
+:warning: defaultTimeoutInterval.test.js passes when not in errorOnDeprecated mode
+```
+### :white_check_mark: <a id="user-content-r0s46" href="#r0s46">e2e/__tests__/esmConfigFile.test.ts</a>
+```
+:white_check_mark: reads config from cjs file
+on node ^12.17.0 || >=13.2.0
+  :white_check_mark: reads config from mjs file
+  :white_check_mark: reads config from js file when package.json#type=module
+```
+### :white_check_mark: <a id="user-content-r0s47" href="#r0s47">e2e/__tests__/executeTestsOnceInMpr.ts</a>
+```
+:white_check_mark: Tests are executed only once even in an MPR
+```
+### :white_check_mark: <a id="user-content-r0s48" href="#r0s48">e2e/__tests__/existentRoots.test.ts</a>
+```
+:white_check_mark: error when rootDir does not exist
+:white_check_mark: error when rootDir is a file
+:white_check_mark: error when roots directory does not exist
+:white_check_mark: error when roots is a file
+```
+### :white_check_mark: <a id="user-content-r0s49" href="#r0s49">e2e/__tests__/expectAsyncMatcher.test.ts</a>
+```
+:white_check_mark: works with passing tests
+:white_check_mark: shows the correct errors in stderr when failing tests
+```
+### :white_check_mark: <a id="user-content-r0s50" href="#r0s50">e2e/__tests__/expectInVm.test.ts</a>
+```
+:white_check_mark: expect works correctly with RegExps created inside a VM
+```
+### :white_check_mark: <a id="user-content-r0s51" href="#r0s51">e2e/__tests__/extraGlobals.test.ts</a>
+```
+:white_check_mark: works with injected globals
+```
+### :white_check_mark: <a id="user-content-r0s52" href="#r0s52">e2e/__tests__/failureDetailsProperty.test.ts</a>
+```
+:white_check_mark: that the failureDetails property is set
+```
+### :white_check_mark: <a id="user-content-r0s53" href="#r0s53">e2e/__tests__/failures.test.ts</a>
+```
+:white_check_mark: not throwing Error objects
+:white_check_mark: works with node assert
+:white_check_mark: works with assertions in separate files
+:white_check_mark: works with async failures
+:white_check_mark: works with snapshot failures
+:white_check_mark: works with snapshot failures with hint
+:white_check_mark: errors after test has completed
+```
+### :white_check_mark: <a id="user-content-r0s54" href="#r0s54">e2e/__tests__/fakePromises.test.ts</a>
+```
+Fake promises
+  :white_check_mark: should be possible to resolve with fake timers using immediates
+  :white_check_mark: should be possible to resolve with fake timers using asap
+```
+### :white_check_mark: <a id="user-content-r0s55" href="#r0s55">e2e/__tests__/fatalWorkerError.test.ts</a>
+```
+:white_check_mark: fails a test that terminates the worker with a fatal error
+```
+### :white_check_mark: <a id="user-content-r0s56" href="#r0s56">e2e/__tests__/filter.test.ts</a>
+```
+Dynamic test filtering
+  :white_check_mark: uses the default JSON option
+  :white_check_mark: uses the CLI option
+  :white_check_mark: ignores the filter if requested to do so
+  :white_check_mark: throws when you return clowny stuff
+  :white_check_mark: will call setup on filter before filtering
+  :white_check_mark: will print error when filter throws
+  :white_check_mark: will return no results when setup hook throws
+```
+### :white_check_mark: <a id="user-content-r0s57" href="#r0s57">e2e/__tests__/findRelatedFiles.test.ts</a>
+```
+--findRelatedTests flag
+  :white_check_mark: runs tests related to filename
+  :white_check_mark: runs tests related to uppercased filename on case-insensitive os
+  :white_check_mark: runs tests related to filename with a custom dependency extractor
+  :white_check_mark: generates coverage report for filename
+  :white_check_mark: coverage configuration is applied correctly
+```
+### :white_check_mark: <a id="user-content-r0s58" href="#r0s58">e2e/__tests__/focusedTests.test.ts</a>
+```
+:white_check_mark: runs only "it.only" tests
+```
+### :white_check_mark: <a id="user-content-r0s59" href="#r0s59">e2e/__tests__/forceExit.test.ts</a>
+```
+:white_check_mark: exits the process after test are done but before timers complete
+```
+### :white_check_mark: <a id="user-content-r0s60" href="#r0s60">e2e/__tests__/generatorMock.test.ts</a>
+```
+:white_check_mark: mock works with generator
+```
+### :white_check_mark: <a id="user-content-r0s61" href="#r0s61">e2e/__tests__/global-mutation.test.ts</a>
+```
+:white_check_mark: can redefine global
+```
+### :white_check_mark: <a id="user-content-r0s62" href="#r0s62">e2e/__tests__/global.test.ts</a>
+```
+:white_check_mark: globals are properly defined
+```
+### :white_check_mark: <a id="user-content-r0s63" href="#r0s63">e2e/__tests__/globals.test.ts</a>
+```
+:white_check_mark: basic test constructs
+:white_check_mark: interleaved describe and test children order
+:white_check_mark: skips
+:white_check_mark: only
+:white_check_mark: cannot have describe with no implementation
+:white_check_mark: cannot test with no implementation
+:white_check_mark: skips with expand arg
+:white_check_mark: only with expand arg
+:white_check_mark: cannot test with no implementation with expand arg
+:white_check_mark: function as descriptor
+```
+### :white_check_mark: <a id="user-content-r0s64" href="#r0s64">e2e/__tests__/globalSetup.test.ts</a>
+```
+:white_check_mark: globalSetup is triggered once before all test suites
+:white_check_mark: jest throws an error when globalSetup does not export a function
+:white_check_mark: globalSetup function gets jest config object as a parameter
+:white_check_mark: should call globalSetup function of multiple projects
+:white_check_mark: should not call a globalSetup of a project if there are no tests to run from this project
+:white_check_mark: should not call any globalSetup if there are no tests to run
+:white_check_mark: globalSetup works with default export
+:white_check_mark: globalSetup throws with named export
+:white_check_mark: should not transpile the transformer
+:white_check_mark: should transform node_modules if configured by transformIgnorePatterns
+```
+### :white_check_mark: <a id="user-content-r0s65" href="#r0s65">e2e/__tests__/globalTeardown.test.ts</a>
+```
+:white_check_mark: globalTeardown is triggered once after all test suites
+:white_check_mark: jest throws an error when globalTeardown does not export a function
+:white_check_mark: globalTeardown function gets jest config object as a parameter
+:white_check_mark: should call globalTeardown function of multiple projects
+:white_check_mark: should not call a globalTeardown of a project if there are no tests to run from this project
+:white_check_mark: globalTeardown works with default export
+:white_check_mark: globalTeardown throws with named export
+```
+### :white_check_mark: <a id="user-content-r0s66" href="#r0s66">e2e/__tests__/hasteMapMockChanged.test.ts</a>
+```
+:white_check_mark: should not warn when a mock file changes
+```
+### :white_check_mark: <a id="user-content-r0s67" href="#r0s67">e2e/__tests__/hasteMapSha1.test.ts</a>
+```
+:white_check_mark: exits the process after test are done but before timers complete
+```
+### :white_check_mark: <a id="user-content-r0s68" href="#r0s68">e2e/__tests__/hasteMapSize.test.ts</a>
+```
+:white_check_mark: reports the correct file size
+:white_check_mark: updates the file size when a file changes
+```
+### :white_check_mark: <a id="user-content-r0s69" href="#r0s69">e2e/__tests__/importedGlobals.test.ts</a>
+```
+:white_check_mark: imported globals
+```
+### :white_check_mark: <a id="user-content-r0s70" href="#r0s70">e2e/__tests__/injectGlobals.test.ts</a>
+```
+:white_check_mark: globals are undefined if passed `false` from CLI
+:white_check_mark: globals are undefined if passed `false` from config
+```
+### :white_check_mark: <a id="user-content-r0s71" href="#r0s71">e2e/__tests__/jasmineAsync.test.ts</a>
+```
+async jasmine
+  :white_check_mark: works with beforeAll
+  :white_check_mark: works with beforeEach
+  :white_check_mark: works with afterAll
+  :white_check_mark: works with afterEach
+  :white_check_mark: works with fit
+  :white_check_mark: works with xit
+  :white_check_mark: throws when not a promise is returned
+  :white_check_mark: tests async promise code
+  :white_check_mark: works with concurrent
+  :white_check_mark: works with concurrent within a describe block when invoked with testNamePattern
+  :white_check_mark: works with concurrent.each
+  :white_check_mark: works with concurrent.only.each
+  :white_check_mark: doesn't execute more than 5 tests simultaneously
+  :white_check_mark: async test fails
+  :white_check_mark: generator test
+```
+### :white_check_mark: <a id="user-content-r0s72" href="#r0s72">e2e/__tests__/jasmineAsyncWithPendingDuringTest.ts</a>
+```
+async jasmine with pending during test
+  :white_check_mark: does not work on jest-circus
+  :warning: should be reported as a pending test
+```
+### :white_check_mark: <a id="user-content-r0s73" href="#r0s73">e2e/__tests__/jest.config.js.test.ts</a>
+```
+:white_check_mark: works with jest.config.js
+:white_check_mark: traverses directory tree up until it finds jest.config
+:white_check_mark: invalid JS in jest.config.js
+```
+### :white_check_mark: <a id="user-content-r0s74" href="#r0s74">e2e/__tests__/jest.config.ts.test.ts</a>
+```
+:white_check_mark: works with jest.config.ts
+:white_check_mark: works with tsconfig.json
+:white_check_mark: traverses directory tree up until it finds jest.config
+:white_check_mark: it does type check the config
+:white_check_mark: invalid JS in jest.config.ts
+```
 ### :x: <a id="user-content-r0s75" href="#r0s75">e2e/__tests__/jestChangedFiles.test.ts</a>
 ```
 :white_check_mark: gets hg SCM roots and dedupes them
@@ -420,6 +898,143 @@
 :white_check_mark: monitors only root paths for hg
 :white_check_mark: handles a bad revision for "changedSince", for hg
 ```
+### :white_check_mark: <a id="user-content-r0s76" href="#r0s76">e2e/__tests__/jestEnvironmentJsdom.test.ts</a>
+```
+:white_check_mark: check is not leaking memory
+```
+### :white_check_mark: <a id="user-content-r0s77" href="#r0s77">e2e/__tests__/jestRequireActual.test.ts</a>
+```
+:white_check_mark: understands dependencies using jest.requireActual
+```
+### :white_check_mark: <a id="user-content-r0s78" href="#r0s78">e2e/__tests__/jestRequireMock.test.ts</a>
+```
+:white_check_mark: understands dependencies using jest.requireMock
+```
+### :white_check_mark: <a id="user-content-r0s79" href="#r0s79">e2e/__tests__/json.test.ts</a>
+```
+:white_check_mark: JSON is available in the global scope
+:white_check_mark: JSON.parse creates objects from within this context
+```
+### :white_check_mark: <a id="user-content-r0s80" href="#r0s80">e2e/__tests__/jsonReporter.test.ts</a>
+```
+JSON Reporter
+  :white_check_mark: writes test result to sum.result.json
+  :white_check_mark: outputs coverage report
+```
+### :white_check_mark: <a id="user-content-r0s81" href="#r0s81">e2e/__tests__/lifecycles.ts</a>
+```
+:white_check_mark: suite with invalid assertions in afterAll
+```
+### :white_check_mark: <a id="user-content-r0s82" href="#r0s82">e2e/__tests__/listTests.test.ts</a>
+```
+--listTests flag
+  :white_check_mark: causes tests to be printed in different lines
+  :white_check_mark: causes tests to be printed out as JSON when using the --json flag
+```
+### :white_check_mark: <a id="user-content-r0s83" href="#r0s83">e2e/__tests__/locationInResults.test.ts</a>
+```
+:white_check_mark: defaults to null for location
+:white_check_mark: adds correct location info when provided with flag
+```
+### :white_check_mark: <a id="user-content-r0s84" href="#r0s84">e2e/__tests__/logHeapUsage.test.ts</a>
+```
+:white_check_mark: logs memory usage
+```
+### :white_check_mark: <a id="user-content-r0s85" href="#r0s85">e2e/__tests__/mockNames.test.ts</a>
+```
+:white_check_mark: suite without mock name, mock called
+:white_check_mark: suite without mock name, mock not called
+:white_check_mark: suite with mock name, expect mock not called
+:white_check_mark: suite with mock name, mock called, expect fail
+:white_check_mark: suite with mock name, mock called 5 times
+:white_check_mark: suite with mock name, mock not called 5 times, expect fail
+:white_check_mark: suite with mock name, mock called
+:white_check_mark: suite with mock name, mock not called
+```
+### :white_check_mark: <a id="user-content-r0s86" href="#r0s86">e2e/__tests__/modernFakeTimers.test.ts</a>
+```
+modern implementation of fake timers
+  :white_check_mark: should be possible to use modern implementation from config
+  :white_check_mark: should be possible to use modern implementation from jest-object
+```
+### :white_check_mark: <a id="user-content-r0s87" href="#r0s87">e2e/__tests__/moduleNameMapper.test.ts</a>
+```
+:white_check_mark: moduleNameMapper wrong configuration
+:white_check_mark: moduleNameMapper wrong array configuration
+:white_check_mark: moduleNameMapper correct configuration
+:white_check_mark: moduleNameMapper correct configuration mocking module of absolute path
+:white_check_mark: moduleNameMapper with mocking
+```
+### :white_check_mark: <a id="user-content-r0s88" href="#r0s88">e2e/__tests__/moduleParentNullInTest.ts</a>
+```
+:white_check_mark: module.parent should be null in test files
+```
+### :white_check_mark: <a id="user-content-r0s89" href="#r0s89">e2e/__tests__/multiProjectRunner.test.ts</a>
+```
+:white_check_mark: --listTests doesn't duplicate the test files
+:white_check_mark: can pass projects or global config
+:white_check_mark: "No tests found" message for projects
+:white_check_mark: allows a single non-root project
+:white_check_mark: allows a single non-root project
+:white_check_mark: correctly runs a single non-root project
+:white_check_mark: correctly runs a single non-root project
+:white_check_mark: projects can be workspaces with non-JS/JSON files
+:white_check_mark: objects in project configuration
+:white_check_mark: allows a single project
+:white_check_mark: resolves projects and their <rootDir> properly
+:white_check_mark: Does transform files with the corresponding project transformer
+doesn't bleed module file extensions resolution with multiple workers
+  :white_check_mark: external config files
+  :white_check_mark: inline config files
+```
+### :white_check_mark: <a id="user-content-r0s90" href="#r0s90">e2e/__tests__/nativeAsyncMock.test.ts</a>
+```
+:white_check_mark: mocks async functions
+```
+### :white_check_mark: <a id="user-content-r0s91" href="#r0s91">e2e/__tests__/nativeEsm.test.ts</a>
+```
+:white_check_mark: test config is without transform
+on node ^12.16.0 || >=13.7.0
+  :white_check_mark: runs test with native ESM
+on node >=14.3.0
+  :warning: supports top-level await
+```
+### :white_check_mark: <a id="user-content-r0s92" href="#r0s92">e2e/__tests__/nativeEsmTypescript.test.ts</a>
+```
+on node ^12.16.0 || >=13.7.0
+  :white_check_mark: runs TS test with native ESM
+```
+### :white_check_mark: <a id="user-content-r0s93" href="#r0s93">e2e/__tests__/nestedEventLoop.test.ts</a>
+```
+:white_check_mark: works with nested event loops
+```
+### :white_check_mark: <a id="user-content-r0s94" href="#r0s94">e2e/__tests__/nestedTestDefinitions.test.ts</a>
+```
+:white_check_mark: print correct error message with nested test definitions outside describe
+:white_check_mark: print correct error message with nested test definitions inside describe
+:white_check_mark: print correct message when nesting describe inside it
+:white_check_mark: print correct message when nesting a hook inside it
+```
+### :white_check_mark: <a id="user-content-r0s95" href="#r0s95">e2e/__tests__/nodePath.test.ts</a>
+```
+:white_check_mark: supports NODE_PATH
+```
+### :white_check_mark: <a id="user-content-r0s96" href="#r0s96">e2e/__tests__/noTestFound.test.ts</a>
+```
+Coverage Report
+  :white_check_mark: outputs coverage report
+File path not found in mulit-project scenario
+  :white_check_mark: outputs coverage report
+```
+### :white_check_mark: <a id="user-content-r0s97" href="#r0s97">e2e/__tests__/noTestsFound.test.ts</a>
+```
+No tests are found
+  :white_check_mark: fails the test suite in standard situation
+  :white_check_mark: doesn't fail the test suite if --passWithNoTests passed
+  :white_check_mark: doesn't fail the test suite if using --lastCommit
+  :white_check_mark: doesn't fail the test suite if using --onlyChanged
+  :white_check_mark: doesn't fail the test suite if using --findRelatedTests
+```
 ### :x: <a id="user-content-r0s98" href="#r0s98">e2e/__tests__/onlyChanged.test.ts</a>
 ```
 :white_check_mark: run for "onlyChanged" and "changedSince"
@@ -432,4 +1047,5416 @@
 :x: gets changed files for hg
 	Error: expect(received).toMatch(expected)
 :white_check_mark: path on Windows is case-insensitive
+```
+### :white_check_mark: <a id="user-content-r0s99" href="#r0s99">e2e/__tests__/onlyFailuresNonWatch.test.ts</a>
+```
+:white_check_mark: onlyFailures flag works in non-watch mode
+```
+### :white_check_mark: <a id="user-content-r0s100" href="#r0s100">e2e/__tests__/overrideGlobals.test.ts</a>
+```
+:white_check_mark: overriding native promise does not freeze Jest
+:white_check_mark: has a duration even if time is faked
+```
+### :white_check_mark: <a id="user-content-r0s101" href="#r0s101">e2e/__tests__/pnp.test.ts</a>
+```
+:white_check_mark: successfully runs the tests inside `pnp/`
+```
+### :white_check_mark: <a id="user-content-r0s102" href="#r0s102">e2e/__tests__/presets.test.ts</a>
+```
+:white_check_mark: supports json preset
+:white_check_mark: supports js preset
+```
+### :white_check_mark: <a id="user-content-r0s103" href="#r0s103">e2e/__tests__/processExit.test.ts</a>
+```
+:white_check_mark: prints stack trace pointing to process.exit call
+```
+### :white_check_mark: <a id="user-content-r0s104" href="#r0s104">e2e/__tests__/promiseReject.test.ts</a>
+```
+:white_check_mark: 
+```
+### :white_check_mark: <a id="user-content-r0s105" href="#r0s105">e2e/__tests__/regexCharInPath.test.ts</a>
+```
+Regex Char In Path
+  :white_check_mark: parses paths containing regex chars correctly
+```
+### :white_check_mark: <a id="user-content-r0s106" href="#r0s106">e2e/__tests__/requireAfterTeardown.test.ts</a>
+```
+:white_check_mark: prints useful error for requires after test is done
+```
+### :white_check_mark: <a id="user-content-r0s107" href="#r0s107">e2e/__tests__/requireMain.test.ts</a>
+```
+:white_check_mark: provides `require.main` set to test suite module
+```
+### :white_check_mark: <a id="user-content-r0s108" href="#r0s108">e2e/__tests__/requireMainAfterCreateRequire.test.ts</a>
+```
+on node >=12.2.0
+  :white_check_mark: `require.main` not undefined after createRequire
+```
+### :white_check_mark: <a id="user-content-r0s109" href="#r0s109">e2e/__tests__/requireMainIsolateModules.test.ts</a>
+```
+:white_check_mark: `require.main` on using `jest.isolateModules` should not be undefined
+```
+### :white_check_mark: <a id="user-content-r0s110" href="#r0s110">e2e/__tests__/requireMainResetModules.test.ts</a>
+```
+:white_check_mark: `require.main` on using `--resetModules='true'` should not be undefined
+:white_check_mark: `require.main` on using `jest.resetModules()` should not be undefined
+```
+### :white_check_mark: <a id="user-content-r0s111" href="#r0s111">e2e/__tests__/requireV8Module.test.ts</a>
+```
+:white_check_mark: v8 module
+```
+### :white_check_mark: <a id="user-content-r0s112" href="#r0s112">e2e/__tests__/resetModules.test.ts</a>
+```
+:white_check_mark: jest.resetModules should not error when _isMockFunction is defined but not boolean
+```
+### :white_check_mark: <a id="user-content-r0s113" href="#r0s113">e2e/__tests__/resolve.test.ts</a>
+```
+:white_check_mark: resolve platform modules
+```
+### :white_check_mark: <a id="user-content-r0s114" href="#r0s114">e2e/__tests__/resolveGetPaths.test.ts</a>
+```
+:white_check_mark: require.resolve.paths
+```
+### :white_check_mark: <a id="user-content-r0s115" href="#r0s115">e2e/__tests__/resolveNodeModule.test.ts</a>
+```
+:white_check_mark: resolve node module
+```
+### :white_check_mark: <a id="user-content-r0s116" href="#r0s116">e2e/__tests__/resolveNoFileExtensions.test.ts</a>
+```
+:white_check_mark: show error message with matching files
+:white_check_mark: show error message when no js moduleFileExtensions
+```
+### :white_check_mark: <a id="user-content-r0s117" href="#r0s117">e2e/__tests__/resolveWithPaths.test.ts</a>
+```
+:white_check_mark: require.resolve with paths
+```
+### :white_check_mark: <a id="user-content-r0s118" href="#r0s118">e2e/__tests__/runProgrammatically.test.ts</a>
+```
+:white_check_mark: run Jest programmatically cjs
+:white_check_mark: run Jest programmatically esm
+```
+### :white_check_mark: <a id="user-content-r0s119" href="#r0s119">e2e/__tests__/runTestsByPath.test.ts</a>
+```
+:white_check_mark: runs tests by exact path
+```
+### :white_check_mark: <a id="user-content-r0s120" href="#r0s120">e2e/__tests__/runtimeInternalModuleRegistry.test.ts</a>
+```
+Runtime Internal Module Registry
+  :white_check_mark: correctly makes use of internal module registry when requiring modules
+```
+### :white_check_mark: <a id="user-content-r0s121" href="#r0s121">e2e/__tests__/selectProjects.test.ts</a>
+```
+Given a config with two named projects, first-project and second-project when Jest is started with `--selectProjects first-project`
+  :white_check_mark: runs the tests in the first project only
+  :white_check_mark: prints that only first-project will run
+Given a config with two named projects, first-project and second-project when Jest is started with `--selectProjects second-project`
+  :white_check_mark: runs the tests in the second project only
+  :white_check_mark: prints that only second-project will run
+Given a config with two named projects, first-project and second-project when Jest is started with `--selectProjects first-project second-project`
+  :white_check_mark: runs the tests in the first and second projects
+  :white_check_mark: prints that both first-project and second-project will run
+Given a config with two named projects, first-project and second-project when Jest is started without providing `--selectProjects`
+  :white_check_mark: runs the tests in the first and second projects
+  :white_check_mark: does not print which projects are run
+Given a config with two named projects, first-project and second-project when Jest is started with `--selectProjects third-project`
+  :white_check_mark: fails
+  :white_check_mark: prints that no project was found
+Given a config with two projects, first-project and an unnamed project when Jest is started with `--selectProjects first-project`
+  :white_check_mark: runs the tests in the first project only
+  :white_check_mark: prints that a project does not have a name
+  :white_check_mark: prints that only first-project will run
+Given a config with two projects, first-project and an unnamed project when Jest is started without providing `--selectProjects`
+  :white_check_mark: runs the tests in the first and second projects
+  :white_check_mark: does not print that a project has no name
+Given a config with two projects, first-project and an unnamed project when Jest is started with `--selectProjects third-project`
+  :white_check_mark: fails
+  :white_check_mark: prints that a project does not have a name
+  :white_check_mark: prints that no project was found
+```
+### :white_check_mark: <a id="user-content-r0s122" href="#r0s122">e2e/__tests__/setImmediate.test.ts</a>
+```
+:white_check_mark: setImmediate
+```
+### :white_check_mark: <a id="user-content-r0s123" href="#r0s123">e2e/__tests__/setupFilesAfterEnvConfig.test.ts</a>
+```
+setupFilesAfterEnv
+  :white_check_mark: requires multiple setup files before each file in the suite
+  :white_check_mark: requires setup files *after* the test runners are required
+```
+### :white_check_mark: <a id="user-content-r0s124" href="#r0s124">e2e/__tests__/showConfig.test.ts</a>
+```
+:white_check_mark: --showConfig outputs config info and exits
+```
+### :white_check_mark: <a id="user-content-r0s125" href="#r0s125">e2e/__tests__/skipBeforeAfterAll.test.ts</a>
+```
+:white_check_mark: correctly skip `beforeAll`s in skipped tests
+```
+### :white_check_mark: <a id="user-content-r0s126" href="#r0s126">e2e/__tests__/snapshot-unknown.test.ts</a>
+```
+Snapshot serializers
+  :white_check_mark: renders snapshot
+```
+### :white_check_mark: <a id="user-content-r0s127" href="#r0s127">e2e/__tests__/snapshot.test.ts</a>
+```
+Snapshot
+  :white_check_mark: stores new snapshots on the first run
+  :white_check_mark: works with escaped characters
+  :white_check_mark: works with escaped regex
+  :white_check_mark: works with template literal substitutions
+Snapshot Validation
+  :white_check_mark: does not save snapshots in CI mode by default
+  :white_check_mark: works on subsequent runs without `-u`
+  :white_check_mark: deletes the snapshot if the test suite has been removed
+  :white_check_mark: deletes a snapshot when a test does removes all the snapshots
+  :white_check_mark: updates the snapshot when a test removes some snapshots
+```
+### :white_check_mark: <a id="user-content-r0s128" href="#r0s128">e2e/__tests__/snapshotMockFs.test.ts</a>
+```
+:white_check_mark: store snapshot even if fs is mocked
+```
+### :white_check_mark: <a id="user-content-r0s129" href="#r0s129">e2e/__tests__/snapshotResolver.test.ts</a>
+```
+Custom snapshot resolver
+  :white_check_mark: Resolves snapshot files using custom resolver
+```
+### :white_check_mark: <a id="user-content-r0s130" href="#r0s130">e2e/__tests__/snapshotSerializers.test.ts</a>
+```
+Snapshot serializers
+  :white_check_mark: renders snapshot
+  :white_check_mark: compares snapshots correctly
+```
+### :white_check_mark: <a id="user-content-r0s131" href="#r0s131">e2e/__tests__/stackTrace.test.ts</a>
+```
+Stack Trace
+  :white_check_mark: prints a stack trace for runtime errors
+  :white_check_mark: does not print a stack trace for runtime errors when --noStackTrace is given
+  :white_check_mark: prints a stack trace for matching errors
+  :white_check_mark: does not print a stack trace for matching errors when --noStackTrace is given
+  :white_check_mark: prints a stack trace for errors
+  :white_check_mark: prints a stack trace for errors without message in stack trace
+  :white_check_mark: does not print a stack trace for errors when --noStackTrace is given
+```
+### :white_check_mark: <a id="user-content-r0s132" href="#r0s132">e2e/__tests__/stackTraceNoCaptureStackTrace.test.ts</a>
+```
+:white_check_mark: prints a usable stack trace even if no Error.captureStackTrace
+```
+### :white_check_mark: <a id="user-content-r0s133" href="#r0s133">e2e/__tests__/stackTraceSourceMaps.test.ts</a>
+```
+:white_check_mark: processes stack traces and code frames with source maps
+```
+### :white_check_mark: <a id="user-content-r0s134" href="#r0s134">e2e/__tests__/stackTraceSourceMapsWithCoverage.test.ts</a>
+```
+:white_check_mark: processes stack traces and code frames with source maps with coverage
+```
+### :white_check_mark: <a id="user-content-r0s135" href="#r0s135">e2e/__tests__/supportsDashedArgs.ts</a>
+```
+:white_check_mark: works with passing tests
+:white_check_mark: throws error for unknown dashed & camelcase args
+```
+### :white_check_mark: <a id="user-content-r0s136" href="#r0s136">e2e/__tests__/symbol.test.ts</a>
+```
+:white_check_mark: Symbol deletion
+```
+### :white_check_mark: <a id="user-content-r0s137" href="#r0s137">e2e/__tests__/testEnvironment.test.ts</a>
+```
+:white_check_mark: respects testEnvironment docblock
+```
+### :white_check_mark: <a id="user-content-r0s138" href="#r0s138">e2e/__tests__/testEnvironmentAsync.test.ts</a>
+```
+:white_check_mark: triggers setup/teardown hooks
+```
+### :white_check_mark: <a id="user-content-r0s139" href="#r0s139">e2e/__tests__/testEnvironmentCircus.test.ts</a>
+```
+:white_check_mark: calls testEnvironment handleTestEvent
+```
+### :white_check_mark: <a id="user-content-r0s140" href="#r0s140">e2e/__tests__/testEnvironmentCircusAsync.test.ts</a>
+```
+:white_check_mark: calls asynchronous handleTestEvent in testEnvironment
+```
+### :white_check_mark: <a id="user-content-r0s141" href="#r0s141">e2e/__tests__/testFailureExitCode.test.ts</a>
+```
+:white_check_mark: exits with a specified code when test fail
+:white_check_mark: exits with a specified code when bailing from a failed test
+```
+### :white_check_mark: <a id="user-content-r0s142" href="#r0s142">e2e/__tests__/testInRoot.test.ts</a>
+```
+:white_check_mark: runs tests in only test.js and spec.js
+```
+### :white_check_mark: <a id="user-content-r0s143" href="#r0s143">e2e/__tests__/testNamePattern.test.ts</a>
+```
+:white_check_mark: testNamePattern
+```
+### :white_check_mark: <a id="user-content-r0s144" href="#r0s144">e2e/__tests__/testNamePatternSkipped.test.ts</a>
+```
+:white_check_mark: testNamePattern skipped
+```
+### :white_check_mark: <a id="user-content-r0s145" href="#r0s145">e2e/__tests__/testPathPatternReporterMessage.test.ts</a>
+```
+:white_check_mark: prints a message with path pattern at the end
+```
+### :white_check_mark: <a id="user-content-r0s146" href="#r0s146">e2e/__tests__/testResultsProcessor.test.ts</a>
+```
+:white_check_mark: testNamePattern
+```
+### :white_check_mark: <a id="user-content-r0s147" href="#r0s147">e2e/__tests__/testRetries.test.ts</a>
+```
+Test Retries
+  :white_check_mark: retries failed tests
+  :white_check_mark: reporter shows more than 1 invocation if test is retried
+  :white_check_mark: reporter shows 1 invocation if tests are not retried
+  :white_check_mark: tests are not retried if beforeAll hook failure occurs
+```
+### :white_check_mark: <a id="user-content-r0s148" href="#r0s148">e2e/__tests__/testTodo.test.ts</a>
+```
+:white_check_mark: works with all statuses
+:white_check_mark: shows error messages when called with no arguments
+:white_check_mark: shows error messages when called with multiple arguments
+:white_check_mark: shows error messages when called with invalid argument
+:white_check_mark: shows todo messages when in verbose mode
+```
+### :white_check_mark: <a id="user-content-r0s149" href="#r0s149">e2e/__tests__/timeouts.test.ts</a>
+```
+:white_check_mark: exceeds the timeout
+:white_check_mark: does not exceed the timeout
+:white_check_mark: exceeds the command line testTimeout
+:white_check_mark: does not exceed the command line testTimeout
+```
+### :white_check_mark: <a id="user-content-r0s150" href="#r0s150">e2e/__tests__/timeoutsLegacy.test.ts</a>
+```
+:white_check_mark: does not work on jest-circus
+:warning: exceeds the timeout set using jasmine.DEFAULT_TIMEOUT_INTERVAL
+:warning: does not exceed the timeout using jasmine.DEFAULT_TIMEOUT_INTERVAL
+:warning: can read and write jasmine.DEFAULT_TIMEOUT_INTERVAL
+```
+### :white_check_mark: <a id="user-content-r0s151" href="#r0s151">e2e/__tests__/timerResetMocks.test.ts</a>
+```
+:white_check_mark: run timers after resetAllMocks test
+:white_check_mark: run timers with resetMocks in config test
+```
+### :white_check_mark: <a id="user-content-r0s152" href="#r0s152">e2e/__tests__/timerUseRealTimers.test.ts</a>
+```
+:white_check_mark: useRealTimers cancels "timers": "fake" for whole test file
+```
+### :white_check_mark: <a id="user-content-r0s153" href="#r0s153">e2e/__tests__/toMatchInlineSnapshot.test.ts</a>
+```
+:white_check_mark: basic support
+:white_check_mark: do not indent empty lines
+:white_check_mark: handles property matchers
+:white_check_mark: removes obsolete external snapshots
+:white_check_mark: supports async matchers
+:white_check_mark: supports async tests
+:white_check_mark: writes snapshots with non-literals in expect(...)
+:white_check_mark: handles mocking native modules prettier relies on
+:white_check_mark: supports custom matchers
+:white_check_mark: supports custom matchers with property matcher
+:white_check_mark: multiple custom matchers and native matchers
+:white_check_mark: indentation is correct in the presences of existing snapshots
+```
+### :white_check_mark: <a id="user-content-r0s154" href="#r0s154">e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts</a>
+```
+:white_check_mark: works with a single snapshot
+:white_check_mark: works when a different assertion is failing
+:white_check_mark: works when multiple tests have snapshots but only one of them failed multiple times
+```
+### :white_check_mark: <a id="user-content-r0s155" href="#r0s155">e2e/__tests__/toMatchSnapshot.test.ts</a>
+```
+:white_check_mark: basic support
+:white_check_mark: error thrown before snapshot
+:white_check_mark: first snapshot fails, second passes
+:white_check_mark: does not mark snapshots as obsolete in skipped tests
+:white_check_mark: accepts custom snapshot name
+:white_check_mark: handles property matchers
+:white_check_mark: handles invalid property matchers
+:white_check_mark: handles property matchers with hint
+:white_check_mark: handles property matchers with deep properties
+```
+### :white_check_mark: <a id="user-content-r0s156" href="#r0s156">e2e/__tests__/toMatchSnapshotWithRetries.test.ts</a>
+```
+:white_check_mark: works with a single snapshot
+:white_check_mark: works when multiple tests have snapshots but only one of them failed multiple times
+```
+### :white_check_mark: <a id="user-content-r0s157" href="#r0s157">e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts</a>
+```
+:white_check_mark: empty external
+:white_check_mark: empty internal ci false
+:white_check_mark: undefined internal ci true
+```
+### :white_check_mark: <a id="user-content-r0s158" href="#r0s158">e2e/__tests__/toThrowErrorMatchingInlineSnapshot.test.ts</a>
+```
+:white_check_mark: works fine when function throws error
+:white_check_mark: updates existing snapshot
+:white_check_mark: cannot be used with .not
+:white_check_mark: should support rejecting promises
+```
+### :white_check_mark: <a id="user-content-r0s159" href="#r0s159">e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts</a>
+```
+:white_check_mark: works fine when function throws error
+:white_check_mark: throws the error if tested function didn't throw error
+:white_check_mark: accepts custom snapshot name
+:white_check_mark: cannot be used with .not
+:white_check_mark: should support rejecting promises
+```
+### :white_check_mark: <a id="user-content-r0s160" href="#r0s160">e2e/__tests__/transform.test.ts</a>
+```
+babel-jest
+  :white_check_mark: runs transpiled code
+  :white_check_mark: instruments only specific files and collects coverage
+babel-jest ignored
+  :white_check_mark: tells user to match ignored files
+babel-jest with manual transformer
+  :white_check_mark: runs transpiled code
+no babel-jest
+  :white_check_mark: fails with syntax error on flow types
+  :white_check_mark: instrumentation with no babel-jest
+custom transformer
+  :white_check_mark: proprocesses files
+  :white_check_mark: instruments files
+multiple-transformers
+  :white_check_mark: transforms dependencies using specific transformers
+ecmascript-modules-support
+  :white_check_mark: runs transpiled code
+transformer-config
+  :white_check_mark: runs transpiled code
+  :white_check_mark: instruments only specific files and collects coverage
+transformer caching
+  :white_check_mark: does not rerun transform within worker
+transform-environment
+  :white_check_mark: should transform the environment
+transform-runner
+  :white_check_mark: should transform runner
+transform-testrunner
+  :white_check_mark: should transform testRunner
+```
+### :white_check_mark: <a id="user-content-r0s161" href="#r0s161">e2e/__tests__/transformLinkedModules.test.ts</a>
+```
+:white_check_mark: should transform linked modules
+```
+### :white_check_mark: <a id="user-content-r0s162" href="#r0s162">e2e/__tests__/typescriptCoverage.test.ts</a>
+```
+:white_check_mark: instruments and collects coverage for typescript files
+```
+### :white_check_mark: <a id="user-content-r0s163" href="#r0s163">e2e/__tests__/unexpectedToken.test.ts</a>
+```
+:white_check_mark: triggers unexpected token error message for non-JS assets
+:white_check_mark: triggers unexpected token error message for untranspiled node_modules
+:white_check_mark: does not trigger unexpected token error message for regular syntax errors
+```
+### :white_check_mark: <a id="user-content-r0s164" href="#r0s164">e2e/__tests__/useStderr.test.ts</a>
+```
+:white_check_mark: no tests found message is redirected to stderr
+```
+### :white_check_mark: <a id="user-content-r0s165" href="#r0s165">e2e/__tests__/v8Coverage.test.ts</a>
+```
+:white_check_mark: prints coverage with missing sourcemaps
+:white_check_mark: prints coverage with empty sourcemaps
+```
+### :white_check_mark: <a id="user-content-r0s166" href="#r0s166">e2e/__tests__/verbose.test.ts</a>
+```
+:white_check_mark: Verbose Reporter
+```
+### :white_check_mark: <a id="user-content-r0s167" href="#r0s167">e2e/__tests__/version.test.ts</a>
+```
+:white_check_mark: works with jest.config.js
+```
+### :white_check_mark: <a id="user-content-r0s168" href="#r0s168">e2e/__tests__/watchModeNoAccess.test.ts</a>
+```
+:white_check_mark: does not re-run tests when only access time is modified
+```
+### :white_check_mark: <a id="user-content-r0s169" href="#r0s169">e2e/__tests__/watchModeOnlyFailed.test.ts</a>
+```
+:white_check_mark: can press "f" to run only failed tests
+```
+### :white_check_mark: <a id="user-content-r0s170" href="#r0s170">e2e/__tests__/watchModePatterns.test.ts</a>
+```
+:white_check_mark: can press "p" to filter by file name
+:white_check_mark: can press "t" to filter by test name
+```
+### :white_check_mark: <a id="user-content-r0s171" href="#r0s171">e2e/__tests__/watchModeUpdateSnapshot.test.ts</a>
+```
+:white_check_mark: can press "u" to update snapshots
+```
+### :white_check_mark: <a id="user-content-r0s172" href="#r0s172">e2e/__tests__/workerForceExit.test.ts</a>
+```
+:white_check_mark: prints a warning if a worker is force exited
+:white_check_mark: force exits a worker that fails to exit gracefully
+```
+### :white_check_mark: <a id="user-content-r0s173" href="#r0s173">e2e/__tests__/wrongEnv.test.ts</a>
+```
+Wrong globals for environment
+  :white_check_mark: print useful error for window
+  :white_check_mark: print useful error for document
+  :white_check_mark: print useful error for navigator
+  :white_check_mark: print useful error for unref
+  :white_check_mark: print useful error when it explodes during evaluation
+```
+### :white_check_mark: <a id="user-content-r0s174" href="#r0s174">e2e/custom-test-sequencer/a.test.js</a>
+```
+:white_check_mark: a
+```
+### :white_check_mark: <a id="user-content-r0s175" href="#r0s175">e2e/custom-test-sequencer/b.test.js</a>
+```
+:white_check_mark: b
+```
+### :white_check_mark: <a id="user-content-r0s176" href="#r0s176">e2e/custom-test-sequencer/c.test.js</a>
+```
+:white_check_mark: c
+```
+### :white_check_mark: <a id="user-content-r0s177" href="#r0s177">e2e/custom-test-sequencer/d.test.js</a>
+```
+:white_check_mark: d
+```
+### :white_check_mark: <a id="user-content-r0s178" href="#r0s178">e2e/custom-test-sequencer/e.test.js</a>
+```
+:white_check_mark: e
+```
+### :white_check_mark: <a id="user-content-r0s179" href="#r0s179">e2e/test-in-root/spec.js</a>
+```
+:white_check_mark: stub
+```
+### :white_check_mark: <a id="user-content-r0s180" href="#r0s180">e2e/test-in-root/test.js</a>
+```
+:white_check_mark: stub
+```
+### :white_check_mark: <a id="user-content-r0s181" href="#r0s181">e2e/timer-reset-mocks/after-reset-all-mocks/timerAndMock.test.js</a>
+```
+timers
+  :white_check_mark: should work before calling resetAllMocks
+  :white_check_mark: should not break after calling resetAllMocks
+```
+### :white_check_mark: <a id="user-content-r0s182" href="#r0s182">e2e/timer-reset-mocks/with-reset-mocks/timerWithMock.test.js</a>
+```
+timers
+  :white_check_mark: should work before calling resetAllMocks
+```
+### :white_check_mark: <a id="user-content-r0s183" href="#r0s183">e2e/v8-coverage/empty-sourcemap/test.ts</a>
+```
+:white_check_mark: dummy-test
+```
+### :white_check_mark: <a id="user-content-r0s184" href="#r0s184">examples/angular/app.component.spec.ts</a>
+```
+AppComponent
+  :white_check_mark: should create the app
+  :white_check_mark: should have as title 'angular'
+  :white_check_mark: should render title in a h1 tag
+```
+### :white_check_mark: <a id="user-content-r0s185" href="#r0s185">examples/angular/shared/data.service.spec.ts</a>
+```
+Service: DataService
+  :white_check_mark: should create service
+  :white_check_mark: should return the right title
+```
+### :white_check_mark: <a id="user-content-r0s186" href="#r0s186">examples/angular/shared/sub.service.spec.ts</a>
+```
+Service: SubService
+  :white_check_mark: should create service
+```
+### :white_check_mark: <a id="user-content-r0s187" href="#r0s187">examples/async/__tests__/user.test.js</a>
+```
+:white_check_mark: works with resolves
+:white_check_mark: works with promises
+:white_check_mark: works with async/await
+:white_check_mark: works with async/await and resolves
+:white_check_mark: tests error with rejects
+:white_check_mark: tests error with promises
+:white_check_mark: tests error with async/await
+:white_check_mark: tests error with async/await and rejects
+```
+### :white_check_mark: <a id="user-content-r0s188" href="#r0s188">examples/automatic-mocks/__tests__/automock.test.js</a>
+```
+:white_check_mark: if utils are mocked
+:white_check_mark: mocked implementation
+```
+### :white_check_mark: <a id="user-content-r0s189" href="#r0s189">examples/automatic-mocks/__tests__/createMockFromModule.test.js</a>
+```
+:white_check_mark: implementation created by automock
+:white_check_mark: implementation created by jest.createMockFromModule
+```
+### :white_check_mark: <a id="user-content-r0s190" href="#r0s190">examples/automatic-mocks/__tests__/disableAutomocking.test.js</a>
+```
+:white_check_mark: original implementation
+```
+### :white_check_mark: <a id="user-content-r0s191" href="#r0s191">examples/enzyme/__tests__/CheckboxWithLabel-test.js</a>
+```
+:white_check_mark: CheckboxWithLabel changes the text after click
+```
+### :white_check_mark: <a id="user-content-r0s192" href="#r0s192">examples/getting-started/sum.test.js</a>
+```
+:white_check_mark: adds 1 + 2 to equal 3
+```
+### :white_check_mark: <a id="user-content-r0s193" href="#r0s193">examples/jquery/__tests__/display_user.test.js</a>
+```
+:white_check_mark: displays a user after a click
+```
+### :white_check_mark: <a id="user-content-r0s194" href="#r0s194">examples/jquery/__tests__/fetch_current_user.test.js</a>
+```
+:white_check_mark: calls into $.ajax with the correct params
+:white_check_mark: calls the callback when $.ajax requests are finished
+```
+### :white_check_mark: <a id="user-content-r0s195" href="#r0s195">examples/manual-mocks/__tests__/file_summarizer.test.js</a>
+```
+listFilesInDirectorySync
+  :white_check_mark: includes all files in the directory in the summary
+```
+### :white_check_mark: <a id="user-content-r0s196" href="#r0s196">examples/manual-mocks/__tests__/lodashMocking.test.js</a>
+```
+:white_check_mark: if lodash head is mocked
+```
+### :white_check_mark: <a id="user-content-r0s197" href="#r0s197">examples/manual-mocks/__tests__/user.test.js</a>
+```
+:white_check_mark: if orginal user model
+```
+### :white_check_mark: <a id="user-content-r0s198" href="#r0s198">examples/manual-mocks/__tests__/userMocked.test.js</a>
+```
+:white_check_mark: if user model is mocked
+```
+### :white_check_mark: <a id="user-content-r0s199" href="#r0s199">examples/module-mock/__tests__/full_mock.js</a>
+```
+:white_check_mark: does a full mock
+```
+### :white_check_mark: <a id="user-content-r0s200" href="#r0s200">examples/module-mock/__tests__/mock_per_test.js</a>
+```
+define mock per test
+  :white_check_mark: uses mocked module
+  :white_check_mark: uses actual module
+```
+### :white_check_mark: <a id="user-content-r0s201" href="#r0s201">examples/module-mock/__tests__/partial_mock.js</a>
+```
+:white_check_mark: does a partial mock
+```
+### :white_check_mark: <a id="user-content-r0s202" href="#r0s202">examples/mongodb/__test__/db.test.js</a>
+```
+:white_check_mark: should aggregate docs from collection
+```
+### :white_check_mark: <a id="user-content-r0s203" href="#r0s203">examples/react-native/__tests__/intro.test.js</a>
+```
+:white_check_mark: renders correctly
+:white_check_mark: renders the ActivityIndicator component
+:white_check_mark: renders the TextInput component
+:white_check_mark: renders the FlatList component
+```
+### :white_check_mark: <a id="user-content-r0s204" href="#r0s204">examples/react-testing-library/__tests__/CheckboxWithLabel-test.js</a>
+```
+:white_check_mark: CheckboxWithLabel changes the text after click
+```
+### :white_check_mark: <a id="user-content-r0s205" href="#r0s205">examples/react/__tests__/CheckboxWithLabel-test.js</a>
+```
+:white_check_mark: CheckboxWithLabel changes the text after click
+```
+### :white_check_mark: <a id="user-content-r0s206" href="#r0s206">examples/snapshot/__tests__/clock.react.test.js</a>
+```
+:white_check_mark: renders correctly
+```
+### :white_check_mark: <a id="user-content-r0s207" href="#r0s207">examples/snapshot/__tests__/link.react.test.js</a>
+```
+:white_check_mark: renders correctly
+:white_check_mark: renders as an anchor when no page is set
+:white_check_mark: properly escapes quotes
+:white_check_mark: changes the class when hovered
+```
+### :white_check_mark: <a id="user-content-r0s208" href="#r0s208">examples/timer/__tests__/infinite_timer_game.test.js</a>
+```
+:white_check_mark: schedules a 10-second timer after 1 second
+```
+### :white_check_mark: <a id="user-content-r0s209" href="#r0s209">examples/timer/__tests__/timer_game.test.js</a>
+```
+timerGame
+  :white_check_mark: waits 1 second before ending the game
+  :white_check_mark: calls the callback after 1 second via runAllTimers
+  :white_check_mark: calls the callback after 1 second via advanceTimersByTime
+```
+### :white_check_mark: <a id="user-content-r0s210" href="#r0s210">examples/typescript/__tests__/calc.test.ts</a>
+```
+calc - mocks
+  :white_check_mark: returns result from subtract
+  :white_check_mark: returns result from sum
+  :white_check_mark: adds last result to memory
+  :white_check_mark: subtracts last result to memory
+  :white_check_mark: clears the memory
+  :white_check_mark: throws an error when invalid Op is passed
+```
+### :white_check_mark: <a id="user-content-r0s211" href="#r0s211">examples/typescript/__tests__/CheckboxWithLabel-test.tsx</a>
+```
+:white_check_mark: CheckboxWithLabel changes the text after click
+```
+### :white_check_mark: <a id="user-content-r0s212" href="#r0s212">examples/typescript/__tests__/sub-test.ts</a>
+```
+:white_check_mark: subtracts 5 - 1 to equal 4 in TypeScript
+```
+### :white_check_mark: <a id="user-content-r0s213" href="#r0s213">examples/typescript/__tests__/sum-test.ts</a>
+```
+:white_check_mark: adds 1 + 2 to equal 3 in TScript
+:white_check_mark: adds 1 + 2 to equal 3 in JavaScript
+```
+### :white_check_mark: <a id="user-content-r0s214" href="#r0s214">examples/typescript/__tests__/sum.test.js</a>
+```
+:white_check_mark: adds 1 + 2 to equal 3 in Typescript
+:white_check_mark: adds 1 + 2 to equal 3 in JavaScript
+```
+### :white_check_mark: <a id="user-content-r0s215" href="#r0s215">packages/babel-jest/src/__tests__/index.ts</a>
+```
+:white_check_mark: Returns source string with inline maps when no transformOptions is passed
+:white_check_mark: can pass null to createTransformer
+caller option correctly merges from defaults and options
+  :white_check_mark: {"supportsDynamicImport":true,"supportsStaticESM":true} -> {"supportsDynamicImport":true,"supportsStaticESM":true}
+  :white_check_mark: {"supportsDynamicImport":false,"supportsStaticESM":false} -> {"supportsDynamicImport":false,"supportsStaticESM":false}
+  :white_check_mark: {"supportsStaticESM":false} -> {"supportsDynamicImport":false,"supportsStaticESM":false}
+  :white_check_mark: {"supportsDynamicImport":true} -> {"supportsDynamicImport":true,"supportsStaticESM":false}
+```
+### :white_check_mark: <a id="user-content-r0s216" href="#r0s216">packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts</a>
+```
+babel-plugin-jest-hoist
+  :white_check_mark: automatic react runtime
+  :white_check_mark: top level mocking
+  :white_check_mark: within a block
+  :white_check_mark: within a block with no siblings
+```
+### :white_check_mark: <a id="user-content-r0s217" href="#r0s217">packages/diff-sequences/src/__tests__/index.property.test.ts</a>
+```
+:white_check_mark: should be reflexive
+:white_check_mark: should find the same number of common items when switching the inputs
+:white_check_mark: should have at most the length of its inputs
+:white_check_mark: should have at most the same number of each character as its inputs
+:white_check_mark: should be a subsequence of its inputs
+:white_check_mark: should be no-op when passing common items
+:white_check_mark: should find the exact common items when one array is subarray of the other
+```
+### :white_check_mark: <a id="user-content-r0s218" href="#r0s218">packages/diff-sequences/src/__tests__/index.test.ts</a>
+```
+invalid arg length
+  :white_check_mark: is not a number
+  :white_check_mark: Infinity is not a safe integer
+  :white_check_mark: Not a Number is not a safe integer
+  :white_check_mark: MAX_SAFE_INTEGER + 1 is not a safe integer
+  :white_check_mark: MIN_SAFE_INTEGER - 1 is not a safe integer
+  :white_check_mark: is a negative integer
+invalid arg callback
+  :white_check_mark: null is not a function
+  :white_check_mark: undefined is not a function
+input callback encapsulates comparison zero and negative zero
+  :white_check_mark: are not common according to Object.is method
+  :white_check_mark: are common according to === operator
+input callback encapsulates comparison Not a Number
+  :white_check_mark: is common according to Object.is method
+  :white_check_mark: is not common according to === operator
+input callback encapsulates sequences
+  :white_check_mark: arrays of strings
+  :white_check_mark: string and array of strings
+  :white_check_mark: strings
+no common items negative zero is equivalent to zero for length
+  :white_check_mark: of a
+  :white_check_mark: of b
+  :white_check_mark: of a and b
+no common items
+  :white_check_mark: a empty and b empty
+  :white_check_mark: a empty and b non-empty
+  :white_check_mark: a non-empty and b empty
+no common items a non-empty and b non-empty
+  :white_check_mark: baDeltaLength 0 even
+  :white_check_mark: baDeltaLength 1 odd
+  :white_check_mark: baDeltaLength 2 even
+  :white_check_mark: baDeltaLength 7 odd
+only common items
+  :white_check_mark: length 1
+  :white_check_mark: length 2
+all common items outside
+  :white_check_mark: preceding changes
+  :white_check_mark: following change
+  :white_check_mark: preceding and following changes in one sequence
+some common items inside and outside
+  :white_check_mark: preceding changes adjacent to common in both sequences
+  :white_check_mark: following changes adjacent to common in both sequences
+all common items inside non-recursive
+  :white_check_mark: move from start to end relative to change
+  :white_check_mark: move from start to end relative to common
+  :white_check_mark: move from start to end relative to change and common
+  :white_check_mark: reverse relative to change
+  :white_check_mark: preceding middle
+  :white_check_mark: following middle
+all common items inside recursive
+  :white_check_mark: prev reverse at depth 1 and preceding at depth 2
+  :white_check_mark: last forward at depth 1 and following at depth 2
+  :white_check_mark: preceding at depth 2 and both at depth 3 of following
+  :white_check_mark: interleaved single change
+  :white_check_mark: interleaved double changes
+  :white_check_mark: optimization decreases iMaxF
+  :white_check_mark: optimization decreases iMaxR
+common substrings
+  :white_check_mark: progress
+  :white_check_mark: regression
+  :white_check_mark: wrapping
+```
+### :white_check_mark: <a id="user-content-r0s219" href="#r0s219">packages/expect/src/__tests__/assertionCounts.test.ts</a>
+```
+.assertions()
+  :white_check_mark: does not throw
+  :white_check_mark: redeclares different assertion count
+  :white_check_mark: expects no assertions
+.hasAssertions()
+  :white_check_mark: does not throw if there is an assertion
+  :white_check_mark: throws if expected is not undefined
+  :white_check_mark: hasAssertions not leaking to global state
+```
+### :white_check_mark: <a id="user-content-r0s220" href="#r0s220">packages/expect/src/__tests__/asymmetricMatchers.test.ts</a>
+```
+:white_check_mark: Any.asymmetricMatch()
+:white_check_mark: Any.toAsymmetricMatcher()
+:white_check_mark: Any.toAsymmetricMatcher() with function name
+:white_check_mark: Any throws when called with empty constructor
+:white_check_mark: Anything matches any type
+:white_check_mark: Anything does not match null and undefined
+:white_check_mark: Anything.toAsymmetricMatcher()
+:white_check_mark: ArrayContaining matches
+:white_check_mark: ArrayContaining does not match
+:white_check_mark: ArrayContaining throws for non-arrays
+:white_check_mark: ArrayNotContaining matches
+:white_check_mark: ArrayNotContaining does not match
+:white_check_mark: ArrayNotContaining throws for non-arrays
+:white_check_mark: ObjectContaining matches
+:white_check_mark: ObjectContaining does not match
+:white_check_mark: ObjectContaining matches defined properties
+:white_check_mark: ObjectContaining matches prototype properties
+:white_check_mark: ObjectContaining throws for non-objects
+:white_check_mark: ObjectContaining does not mutate the sample
+:white_check_mark: ObjectNotContaining matches
+:white_check_mark: ObjectNotContaining does not match
+:white_check_mark: ObjectNotContaining inverts ObjectContaining
+:white_check_mark: ObjectNotContaining throws for non-objects
+:white_check_mark: StringContaining matches string against string
+:white_check_mark: StringContaining throws if expected value is not string
+:white_check_mark: StringContaining returns false if received value is not string
+:white_check_mark: StringNotContaining matches string against string
+:white_check_mark: StringNotContaining throws if expected value is not string
+:white_check_mark: StringNotContaining returns true if received value is not string
+:white_check_mark: StringMatching matches string against regexp
+:white_check_mark: StringMatching matches string against string
+:white_check_mark: StringMatching throws if expected value is neither string nor regexp
+:white_check_mark: StringMatching returns false if received value is not string
+:white_check_mark: StringMatching returns false even if coerced non-string received value matches pattern
+:white_check_mark: StringNotMatching matches string against regexp
+:white_check_mark: StringNotMatching matches string against string
+:white_check_mark: StringNotMatching throws if expected value is neither string nor regexp
+:white_check_mark: StringNotMatching returns true if received value is not string
+```
+### :white_check_mark: <a id="user-content-r0s221" href="#r0s221">packages/expect/src/__tests__/extend.test.ts</a>
+```
+:white_check_mark: is available globally when matcher is unary
+:white_check_mark: is available globally when matcher is variadic
+:white_check_mark: exposes matcherUtils in context
+:white_check_mark: is ok if there is no message specified
+:white_check_mark: exposes an equality function to custom matchers
+:white_check_mark: defines asymmetric unary matchers
+:white_check_mark: defines asymmetric unary matchers that can be prefixed by not
+:white_check_mark: defines asymmetric variadic matchers
+:white_check_mark: defines asymmetric variadic matchers that can be prefixed by not
+:white_check_mark: prints the Symbol into the error message
+```
+### :white_check_mark: <a id="user-content-r0s222" href="#r0s222">packages/expect/src/__tests__/isError.test.ts</a>
+```
+isError
+  :white_check_mark: should not assume objects are errors
+  :white_check_mark: should detect simple error instances
+  :white_check_mark: should detect errors from another context
+  :white_check_mark: should detect DOMException errors from another context
+```
+### :white_check_mark: <a id="user-content-r0s223" href="#r0s223">packages/expect/src/__tests__/matchers-toContain.property.test.ts</a>
+```
+toContain
+  :white_check_mark: should always find the value when inside the array
+  :white_check_mark: should not find the value if it has been cloned into the array
+```
+### :white_check_mark: <a id="user-content-r0s224" href="#r0s224">packages/expect/src/__tests__/matchers-toContainEqual.property.test.ts</a>
+```
+toContainEqual
+  :white_check_mark: should always find the value when inside the array
+  :white_check_mark: should always find the value when cloned inside the array
+```
+### :white_check_mark: <a id="user-content-r0s225" href="#r0s225">packages/expect/src/__tests__/matchers-toEqual.property.test.ts</a>
+```
+toEqual
+  :white_check_mark: should be reflexive
+  :white_check_mark: should be symmetric
+```
+### :white_check_mark: <a id="user-content-r0s226" href="#r0s226">packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts</a>
+```
+toStrictEqual
+  :white_check_mark: should be reflexive
+  :white_check_mark: should be symmetric
+toStrictEqual on node >=9
+  :white_check_mark: should be equivalent to Node deepStrictEqual
+```
+### :white_check_mark: <a id="user-content-r0s227" href="#r0s227">packages/expect/src/__tests__/matchers.test.js</a>
+```
+:white_check_mark: should throw if passed two arguments
+.rejects
+  :white_check_mark: should reject
+  :white_check_mark: should reject with toThrow
+  :white_check_mark: should reject async function to toThrow
+  :white_check_mark: fails non-promise value "a" synchronously
+  :white_check_mark: fails non-promise value "a"
+  :white_check_mark: fails non-promise value [1] synchronously
+  :white_check_mark: fails non-promise value [1]
+  :white_check_mark: fails non-promise value [Function anonymous] synchronously
+  :white_check_mark: fails non-promise value [Function anonymous]
+  :white_check_mark: fails non-promise value {"a": 1} synchronously
+  :white_check_mark: fails non-promise value {"a": 1}
+  :white_check_mark: fails non-promise value 4 synchronously
+  :white_check_mark: fails non-promise value 4
+  :white_check_mark: fails non-promise value null synchronously
+  :white_check_mark: fails non-promise value null
+  :white_check_mark: fails non-promise value true synchronously
+  :white_check_mark: fails non-promise value true
+  :white_check_mark: fails non-promise value undefined synchronously
+  :white_check_mark: fails non-promise value undefined
+  :white_check_mark: fails for promise that resolves
+.resolves
+  :white_check_mark: should resolve
+  :white_check_mark: fails non-promise value "a" synchronously
+  :white_check_mark: fails non-promise value "a"
+  :white_check_mark: fails non-promise value [1] synchronously
+  :white_check_mark: fails non-promise value [1]
+  :white_check_mark: fails non-promise value [Function anonymous] synchronously
+  :white_check_mark: fails non-promise value [Function anonymous]
+  :white_check_mark: fails non-promise value {"a": 1} synchronously
+  :white_check_mark: fails non-promise value {"a": 1}
+  :white_check_mark: fails non-promise value 4 synchronously
+  :white_check_mark: fails non-promise value 4
+  :white_check_mark: fails non-promise value null synchronously
+  :white_check_mark: fails non-promise value null
+  :white_check_mark: fails non-promise value true synchronously
+  :white_check_mark: fails non-promise value true
+  :white_check_mark: fails non-promise value undefined synchronously
+  :white_check_mark: fails non-promise value undefined
+  :white_check_mark: fails for promise that rejects
+.toBe()
+  :white_check_mark: does not throw
+  :white_check_mark: fails for: 1 and 2
+  :white_check_mark: fails for: true and false
+  :white_check_mark: fails for: [Function anonymous] and [Function anonymous]
+  :white_check_mark: fails for: {} and {}
+  :white_check_mark: fails for: {"a": 1} and {"a": 1}
+  :white_check_mark: fails for: {"a": 1} and {"a": 5}
+  :white_check_mark: fails for: {"a": [Function a], "b": 2} and {"a": Any<Function>, "b": 2}
+  :white_check_mark: fails for: {"a": undefined, "b": 2} and {"b": 2}
+  :white_check_mark: fails for: 2020-02-20T00:00:00.000Z and 2020-02-20T00:00:00.000Z
+  :white_check_mark: fails for: 2020-02-21T00:00:00.000Z and 2020-02-20T00:00:00.000Z
+  :white_check_mark: fails for: /received/ and /expected/
+  :white_check_mark: fails for: Symbol(received) and Symbol(expected)
+  :white_check_mark: fails for: [Error: received] and [Error: expected]
+  :white_check_mark: fails for: "abc" and "cde"
+  :white_check_mark: fails for: "painless JavaScript testing" and "delightful JavaScript testing"
+  :white_check_mark: fails for: "" and "compare one-line string to empty string"
+  :white_check_mark: fails for: "with 
+trailing space" and "without trailing space"
+  :white_check_mark: fails for: "four
+4
+line
+string" and "3
+line
+string"
+  :white_check_mark: fails for: [] and []
+  :white_check_mark: fails for: null and undefined
+  :white_check_mark: fails for: -0 and 0
+  :white_check_mark: fails for: 1n and 2n
+  :white_check_mark: fails for: {"a": 1n} and {"a": 1n}
+  :white_check_mark: fails for 'false' with '.not'
+  :white_check_mark: fails for '1' with '.not'
+  :white_check_mark: fails for '"a"' with '.not'
+  :white_check_mark: fails for 'undefined' with '.not'
+  :white_check_mark: fails for 'null' with '.not'
+  :white_check_mark: fails for '{}' with '.not'
+  :white_check_mark: fails for '[]' with '.not'
+  :white_check_mark: fails for '1n' with '.not'
+  :white_check_mark: fails for '1n' with '.not'
+  :white_check_mark: does not crash on circular references
+  :white_check_mark: assertion error matcherResult property contains matcher name, expected and actual values
+.toStrictEqual()
+  :white_check_mark: does not ignore keys with undefined values
+  :white_check_mark: does not ignore keys with undefined values inside an array
+  :white_check_mark: does not ignore keys with undefined values deep inside an object
+  :white_check_mark: passes when comparing same type
+  :white_check_mark: matches the expected snapshot when it fails
+  :white_check_mark: displays substring diff
+  :white_check_mark: displays substring diff for multiple lines
+  :white_check_mark: does not pass for different types
+  :white_check_mark: does not simply compare constructor names
+  :white_check_mark: passes for matching sparse arrays
+  :white_check_mark: does not pass when sparseness of arrays do not match
+  :white_check_mark: does not pass when equally sparse arrays have different values
+.toEqual()
+  :white_check_mark: {pass: false} expect(true).toEqual(false)
+  :white_check_mark: {pass: false} expect(1).toEqual(2)
+  :white_check_mark: {pass: false} expect(0).toEqual(-0)
+  :white_check_mark: {pass: false} expect(0).toEqual(5e-324)
+  :white_check_mark: {pass: false} expect(5e-324).toEqual(0)
+  :white_check_mark: {pass: false} expect(0).toEqual({})
+  :white_check_mark: {pass: false} expect({}).toEqual(0)
+  :white_check_mark: {pass: false} expect({}).toEqual({})
+  :white_check_mark: {pass: false} expect("abc").toEqual({"0": "a", "1": "b", "2": "c"})
+  :white_check_mark: {pass: false} expect({"0": "a", "1": "b", "2": "c"}).toEqual("abc")
+  :white_check_mark: {pass: false} expect(/abc/gsy).toEqual(/abc/g)
+  :white_check_mark: {pass: false} expect({"a": 1}).toEqual({"a": 2})
+  :white_check_mark: {pass: false} expect({"a": 5}).toEqual({"b": 6})
+  :white_check_mark: {pass: false} expect({"foo": {"bar": 1}}).toEqual({"foo": {}})
+  :white_check_mark: {pass: false} expect({"getterAndSetter": {}}).toEqual({"getterAndSetter": {"foo": "bar"}})
+  :white_check_mark: {pass: false} expect({"frozenGetterAndSetter": {}}).toEqual({"frozenGetterAndSetter": {"foo": "bar"}})
+  :white_check_mark: {pass: false} expect({"getter": {}}).toEqual({"getter": {"foo": "bar"}})
+  :white_check_mark: {pass: false} expect({"frozenGetter": {}}).toEqual({"frozenGetter": {"foo": "bar"}})
+  :white_check_mark: {pass: false} expect({"setter": undefined}).toEqual({"setter": {"foo": "bar"}})
+  :white_check_mark: {pass: false} expect({"frozenSetter": undefined}).toEqual({"frozenSetter": {"foo": "bar"}})
+  :white_check_mark: {pass: false} expect("banana").toEqual("apple")
+  :white_check_mark: {pass: false} expect("1 234,57 $").toEqual("1 234,57 $")
+  :white_check_mark: {pass: false} expect("type TypeName<T> = T extends Function ? \"function\" : \"object\";").toEqual("type TypeName<T> = T extends Function
+? \"function\"
+: \"object\";")
+  :white_check_mark: {pass: false} expect(null).toEqual(undefined)
+  :white_check_mark: {pass: false} expect([1]).toEqual([2])
+  :white_check_mark: {pass: false} expect([1, 2]).toEqual([2, 1])
+  :white_check_mark: {pass: false} expect(Immutable.List [1]).toEqual(Immutable.List [2])
+  :white_check_mark: {pass: false} expect(Immutable.List [1, 2]).toEqual(Immutable.List [2, 1])
+  :white_check_mark: {pass: false} expect(Map {}).toEqual(Set {})
+  :white_check_mark: {pass: false} expect(Set {1, 2}).toEqual(Set {})
+  :white_check_mark: {pass: false} expect(Set {1, 2}).toEqual(Set {1, 2, 3})
+  :white_check_mark: {pass: false} expect(Set {[1], [2]}).toEqual(Set {[1], [2], [3]})
+  :white_check_mark: {pass: false} expect(Set {[1], [2]}).toEqual(Set {[1], [2], [2]})
+  :white_check_mark: {pass: false} expect(Set {Set {1}, Set {2}}).toEqual(Set {Set {1}, Set {3}})
+  :white_check_mark: {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable.Set [])
+  :white_check_mark: {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable.Set [1, 2, 3])
+  :white_check_mark: {pass: false} expect(Immutable.OrderedSet [1, 2]).toEqual(Immutable.OrderedSet [2, 1])
+  :white_check_mark: {pass: false} expect(Map {1 => "one", 2 => "two"}).toEqual(Map {1 => "one"})
+  :white_check_mark: {pass: false} expect(Map {"a" => 0}).toEqual(Map {"b" => 0})
+  :white_check_mark: {pass: false} expect(Map {"v" => 1}).toEqual(Map {"v" => 2})
+  :white_check_mark: {pass: false} expect(Map {["v"] => 1}).toEqual(Map {["v"] => 2})
+  :white_check_mark: {pass: false} expect(Map {[1] => Map {[1] => "one"}}).toEqual(Map {[1] => Map {[1] => "two"}})
+  :white_check_mark: {pass: false} expect(Immutable.Map {"a": 0}).toEqual(Immutable.Map {"b": 0})
+  :white_check_mark: {pass: false} expect(Immutable.Map {"v": 1}).toEqual(Immutable.Map {"v": 2})
+  :white_check_mark: {pass: false} expect(Immutable.OrderedMap {1: "one", 2: "two"}).toEqual(Immutable.OrderedMap {2: "two", 1: "one"})
+  :white_check_mark: {pass: false} expect(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}).toEqual(Immutable.Map {"1": Immutable.Map {"2": {"a": 11}}})
+  :white_check_mark: {pass: false} expect([97, 98, 99]).toEqual([97, 98, 100])
+  :white_check_mark: {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2})
+  :white_check_mark: {pass: false} expect(false).toEqual(ObjectContaining {"a": 2})
+  :white_check_mark: {pass: false} expect([1, 3]).toEqual(ArrayContaining [1, 2])
+  :white_check_mark: {pass: false} expect(1).toEqual(ArrayContaining [1, 2])
+  :white_check_mark: {pass: false} expect("abd").toEqual(StringContaining "bc")
+  :white_check_mark: {pass: false} expect("abd").toEqual(StringMatching /bc/i)
+  :white_check_mark: {pass: false} expect(undefined).toEqual(Anything)
+  :white_check_mark: {pass: false} expect(undefined).toEqual(Any<Function>)
+  :white_check_mark: {pass: false} expect("Eve").toEqual({"asymmetricMatch": [Function asymmetricMatch]})
+  :white_check_mark: {pass: false} expect({"target": {"nodeType": 1, "value": "a"}}).toEqual({"target": {"nodeType": 1, "value": "b"}})
+  :white_check_mark: {pass: false} expect({"nodeName": "div", "nodeType": 1}).toEqual({"nodeName": "p", "nodeType": 1})
+  :white_check_mark: {pass: false} expect({Symbol(foo): 1, Symbol(bar): 2}).toEqual({Symbol(foo): Any<Number>, Symbol(bar): 1})
+  :white_check_mark: {pass: false} expect(1n).toEqual(2n)
+  :white_check_mark: {pass: false} expect(1n).toEqual(1)
+  :white_check_mark: {pass: true} expect(true).not.toEqual(true)
+  :white_check_mark: {pass: true} expect(1).not.toEqual(1)
+  :white_check_mark: {pass: true} expect(NaN).not.toEqual(NaN)
+  :white_check_mark: {pass: true} expect(0).not.toEqual(0)
+  :white_check_mark: {pass: true} expect(0).not.toEqual(0)
+  :white_check_mark: {pass: true} expect({}).not.toEqual({})
+  :white_check_mark: {pass: true} expect("abc").not.toEqual("abc")
+  :white_check_mark: {pass: true} expect("abc").not.toEqual("abc")
+  :white_check_mark: {pass: true} expect("abc").not.toEqual("abc")
+  :white_check_mark: {pass: true} expect([1]).not.toEqual([1])
+  :white_check_mark: {pass: true} expect([1, 2]).not.toEqual([1, 2])
+  :white_check_mark: {pass: true} expect(Immutable.List [1]).not.toEqual(Immutable.List [1])
+  :white_check_mark: {pass: true} expect(Immutable.List [1, 2]).not.toEqual(Immutable.List [1, 2])
+  :white_check_mark: {pass: true} expect({}).not.toEqual({})
+  :white_check_mark: {pass: true} expect({"a": 99}).not.toEqual({"a": 99})
+  :white_check_mark: {pass: true} expect(Set {}).not.toEqual(Set {})
+  :white_check_mark: {pass: true} expect(Set {1, 2}).not.toEqual(Set {1, 2})
+  :white_check_mark: {pass: true} expect(Set {1, 2}).not.toEqual(Set {2, 1})
+  :white_check_mark: {pass: true} expect(Set {[1], [2]}).not.toEqual(Set {[2], [1]})
+  :white_check_mark: {pass: true} expect(Set {Set {[1]}, Set {[2]}}).not.toEqual(Set {Set {[2]}, Set {[1]}})
+  :white_check_mark: {pass: true} expect(Set {[1], [2], [3], [3]}).not.toEqual(Set {[3], [3], [2], [1]})
+  :white_check_mark: {pass: true} expect(Set {{"a": 1}, {"b": 2}}).not.toEqual(Set {{"b": 2}, {"a": 1}})
+  :white_check_mark: {pass: true} expect(Immutable.Set []).not.toEqual(Immutable.Set [])
+  :white_check_mark: {pass: true} expect(Immutable.Set [1, 2]).not.toEqual(Immutable.Set [1, 2])
+  :white_check_mark: {pass: true} expect(Immutable.Set [1, 2]).not.toEqual(Immutable.Set [2, 1])
+  :white_check_mark: {pass: true} expect(Immutable.OrderedSet []).not.toEqual(Immutable.OrderedSet [])
+  :white_check_mark: {pass: true} expect(Immutable.OrderedSet [1, 2]).not.toEqual(Immutable.OrderedSet [1, 2])
+  :white_check_mark: {pass: true} expect(Map {}).not.toEqual(Map {})
+  :white_check_mark: {pass: true} expect(Map {1 => "one", 2 => "two"}).not.toEqual(Map {1 => "one", 2 => "two"})
+  :white_check_mark: {pass: true} expect(Map {1 => "one", 2 => "two"}).not.toEqual(Map {2 => "two", 1 => "one"})
+  :white_check_mark: {pass: true} expect(Map {[1] => "one", [2] => "two", [3] => "three", [3] => "four"}).not.toEqual(Map {[3] => "three", [3] => "four", [2] => "two", [1] => "one"})
+  :white_check_mark: {pass: true} expect(Map {[1] => Map {[1] => "one"}, [2] => Map {[2] => "two"}}).not.toEqual(Map {[2] => Map {[2] => "two"}, [1] => Map {[1] => "one"}})
+  :white_check_mark: {pass: true} expect(Map {[1] => "one", [2] => "two"}).not.toEqual(Map {[2] => "two", [1] => "one"})
+  :white_check_mark: {pass: true} expect(Map {{"a": 1} => "one", {"b": 2} => "two"}).not.toEqual(Map {{"b": 2} => "two", {"a": 1} => "one"})
+  :white_check_mark: {pass: true} expect(Map {1 => ["one"], 2 => ["two"]}).not.toEqual(Map {2 => ["two"], 1 => ["one"]})
+  :white_check_mark: {pass: true} expect(Immutable.Map {}).not.toEqual(Immutable.Map {})
+  :white_check_mark: {pass: true} expect(Immutable.Map {1: "one", 2: "two"}).not.toEqual(Immutable.Map {1: "one", 2: "two"})
+  :white_check_mark: {pass: true} expect(Immutable.Map {1: "one", 2: "two"}).not.toEqual(Immutable.Map {2: "two", 1: "one"})
+  :white_check_mark: {pass: true} expect(Immutable.OrderedMap {1: "one", 2: "two"}).not.toEqual(Immutable.OrderedMap {1: "one", 2: "two"})
+  :white_check_mark: {pass: true} expect(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}).not.toEqual(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}})
+  :white_check_mark: {pass: true} expect([97, 98, 99]).not.toEqual([97, 98, 99])
+  :white_check_mark: {pass: true} expect({"a": 1, "b": 2}).not.toEqual(ObjectContaining {"a": 1})
+  :white_check_mark: {pass: true} expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3])
+  :white_check_mark: {pass: true} expect("abcd").not.toEqual(StringContaining "bc")
+  :white_check_mark: {pass: true} expect("abcd").not.toEqual(StringMatching /bc/)
+  :white_check_mark: {pass: true} expect(true).not.toEqual(Anything)
+  :white_check_mark: {pass: true} expect([Function anonymous]).not.toEqual(Any<Function>)
+  :white_check_mark: {pass: true} expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything})
+  :white_check_mark: {pass: true} expect("Alice").not.toEqual({"asymmetricMatch": [Function asymmetricMatch]})
+  :white_check_mark: {pass: true} expect({"nodeName": "div", "nodeType": 1}).not.toEqual({"nodeName": "div", "nodeType": 1})
+  :white_check_mark: {pass: true} expect({Symbol(foo): 1, Symbol(bar): 2}).not.toEqual({Symbol(foo): Any<Number>, Symbol(bar): 2})
+  :white_check_mark: {pass: true} expect(1n).not.toEqual(1n)
+  :white_check_mark: {pass: true} expect(0n).not.toEqual(0n)
+  :white_check_mark: {pass: true} expect([1n]).not.toEqual([1n])
+  :white_check_mark: {pass: true} expect([1n, 2]).not.toEqual([1n, 2])
+  :white_check_mark: {pass: true} expect(Immutable.List [1n]).not.toEqual(Immutable.List [1n])
+  :white_check_mark: {pass: true} expect({"a": 99n}).not.toEqual({"a": 99n})
+  :white_check_mark: {pass: true} expect(Set {1n, 2n}).not.toEqual(Set {1n, 2n})
+  :white_check_mark: assertion error matcherResult property contains matcher name, expected and actual values
+  :white_check_mark: symbol based keys in arrays are processed correctly
+  :white_check_mark: non-enumerable members should be skipped during equal
+  :white_check_mark: non-enumerable symbolic members should be skipped during equal
+.toEqual() cyclic object equality
+  :white_check_mark: properties with the same circularity are equal
+  :white_check_mark: properties with different circularity are not equal
+  :white_check_mark: are not equal if circularity is not on the same property
+.toBeInstanceOf()
+  :white_check_mark: passing Map {} and [Function Map]
+  :white_check_mark: passing [] and [Function Array]
+  :white_check_mark: passing {} and [Function A]
+  :white_check_mark: passing {} and [Function B]
+  :white_check_mark: passing {} and [Function B]
+  :white_check_mark: passing {} and [Function anonymous]
+  :white_check_mark: passing {} and [Function B]
+  :white_check_mark: passing {} and [Function name() {}]
+  :white_check_mark: failing "a" and [Function String]
+  :white_check_mark: failing 1 and [Function Number]
+  :white_check_mark: failing true and [Function Boolean]
+  :white_check_mark: failing {} and [Function B]
+  :white_check_mark: failing {} and [Function A]
+  :white_check_mark: failing undefined and [Function String]
+  :white_check_mark: failing null and [Function String]
+  :white_check_mark: failing /\w+/ and [Function anonymous]
+  :white_check_mark: failing {} and [Function RegExp]
+  :white_check_mark: throws if constructor is not a function
+.toBeTruthy(), .toBeFalsy()
+  :white_check_mark: does not accept arguments
+  :white_check_mark: '{}' is truthy
+  :white_check_mark: '[]' is truthy
+  :white_check_mark: 'true' is truthy
+  :white_check_mark: '1' is truthy
+  :white_check_mark: '"a"' is truthy
+  :white_check_mark: '0.5' is truthy
+  :white_check_mark: 'Map {}' is truthy
+  :white_check_mark: '[Function anonymous]' is truthy
+  :white_check_mark: 'Infinity' is truthy
+  :white_check_mark: '1n' is truthy
+  :white_check_mark: 'false' is falsy
+  :white_check_mark: 'null' is falsy
+  :white_check_mark: 'NaN' is falsy
+  :white_check_mark: '0' is falsy
+  :white_check_mark: '""' is falsy
+  :white_check_mark: 'undefined' is falsy
+  :white_check_mark: '0n' is falsy
+.toBeNaN()
+  :white_check_mark: {pass: true} expect(NaN).toBeNaN()
+  :white_check_mark: throws
+.toBeNull()
+  :white_check_mark: fails for '{}'
+  :white_check_mark: fails for '[]'
+  :white_check_mark: fails for 'true'
+  :white_check_mark: fails for '1'
+  :white_check_mark: fails for '"a"'
+  :white_check_mark: fails for '0.5'
+  :white_check_mark: fails for 'Map {}'
+  :white_check_mark: fails for '[Function anonymous]'
+  :white_check_mark: fails for 'Infinity'
+  :white_check_mark: fails for null with .not
+  :white_check_mark: pass for null
+.toBeDefined(), .toBeUndefined()
+  :white_check_mark: '{}' is defined
+  :white_check_mark: '[]' is defined
+  :white_check_mark: 'true' is defined
+  :white_check_mark: '1' is defined
+  :white_check_mark: '"a"' is defined
+  :white_check_mark: '0.5' is defined
+  :white_check_mark: 'Map {}' is defined
+  :white_check_mark: '[Function anonymous]' is defined
+  :white_check_mark: 'Infinity' is defined
+  :white_check_mark: '1n' is defined
+  :white_check_mark: undefined is undefined
+.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual()
+  :white_check_mark: {pass: true} expect(1).toBeLessThan(2)
+  :white_check_mark: {pass: false} expect(2).toBeLessThan(1)
+  :white_check_mark: {pass: true} expect(2).toBeGreaterThan(1)
+  :white_check_mark: {pass: false} expect(1).toBeGreaterThan(2)
+  :white_check_mark: {pass: true} expect(1).toBeLessThanOrEqual(2)
+  :white_check_mark: {pass: false} expect(2).toBeLessThanOrEqual(1)
+  :white_check_mark: {pass: true} expect(2).toBeGreaterThanOrEqual(1)
+  :white_check_mark: {pass: false} expect(1).toBeGreaterThanOrEqual(2)
+  :white_check_mark: throws: [1, 2]
+  :white_check_mark: {pass: true} expect(-Infinity).toBeLessThan(Infinity)
+  :white_check_mark: {pass: false} expect(Infinity).toBeLessThan(-Infinity)
+  :white_check_mark: {pass: true} expect(Infinity).toBeGreaterThan(-Infinity)
+  :white_check_mark: {pass: false} expect(-Infinity).toBeGreaterThan(Infinity)
+  :white_check_mark: {pass: true} expect(-Infinity).toBeLessThanOrEqual(Infinity)
+  :white_check_mark: {pass: false} expect(Infinity).toBeLessThanOrEqual(-Infinity)
+  :white_check_mark: {pass: true} expect(Infinity).toBeGreaterThanOrEqual(-Infinity)
+  :white_check_mark: {pass: false} expect(-Infinity).toBeGreaterThanOrEqual(Infinity)
+  :white_check_mark: throws: [-Infinity, Infinity]
+  :white_check_mark: {pass: true} expect(5e-324).toBeLessThan(1.7976931348623157e+308)
+  :white_check_mark: {pass: false} expect(1.7976931348623157e+308).toBeLessThan(5e-324)
+  :white_check_mark: {pass: true} expect(1.7976931348623157e+308).toBeGreaterThan(5e-324)
+  :white_check_mark: {pass: false} expect(5e-324).toBeGreaterThan(1.7976931348623157e+308)
+  :white_check_mark: {pass: true} expect(5e-324).toBeLessThanOrEqual(1.7976931348623157e+308)
+  :white_check_mark: {pass: false} expect(1.7976931348623157e+308).toBeLessThanOrEqual(5e-324)
+  :white_check_mark: {pass: true} expect(1.7976931348623157e+308).toBeGreaterThanOrEqual(5e-324)
+  :white_check_mark: {pass: false} expect(5e-324).toBeGreaterThanOrEqual(1.7976931348623157e+308)
+  :white_check_mark: throws: [5e-324, 1.7976931348623157e+308]
+  :white_check_mark: {pass: true} expect(17).toBeLessThan(34)
+  :white_check_mark: {pass: false} expect(34).toBeLessThan(17)
+  :white_check_mark: {pass: true} expect(34).toBeGreaterThan(17)
+  :white_check_mark: {pass: false} expect(17).toBeGreaterThan(34)
+  :white_check_mark: {pass: true} expect(17).toBeLessThanOrEqual(34)
+  :white_check_mark: {pass: false} expect(34).toBeLessThanOrEqual(17)
+  :white_check_mark: {pass: true} expect(34).toBeGreaterThanOrEqual(17)
+  :white_check_mark: {pass: false} expect(17).toBeGreaterThanOrEqual(34)
+  :white_check_mark: throws: [17, 34]
+  :white_check_mark: {pass: true} expect(3).toBeLessThan(7)
+  :white_check_mark: {pass: false} expect(7).toBeLessThan(3)
+  :white_check_mark: {pass: true} expect(7).toBeGreaterThan(3)
+  :white_check_mark: {pass: false} expect(3).toBeGreaterThan(7)
+  :white_check_mark: {pass: true} expect(3).toBeLessThanOrEqual(7)
+  :white_check_mark: {pass: false} expect(7).toBeLessThanOrEqual(3)
+  :white_check_mark: {pass: true} expect(7).toBeGreaterThanOrEqual(3)
+  :white_check_mark: {pass: false} expect(3).toBeGreaterThanOrEqual(7)
+  :white_check_mark: throws: [3, 7]
+  :white_check_mark: {pass: true} expect(9).toBeLessThan(18)
+  :white_check_mark: {pass: false} expect(18).toBeLessThan(9)
+  :white_check_mark: {pass: true} expect(18).toBeGreaterThan(9)
+  :white_check_mark: {pass: false} expect(9).toBeGreaterThan(18)
+  :white_check_mark: {pass: true} expect(9).toBeLessThanOrEqual(18)
+  :white_check_mark: {pass: false} expect(18).toBeLessThanOrEqual(9)
+  :white_check_mark: {pass: true} expect(18).toBeGreaterThanOrEqual(9)
+  :white_check_mark: {pass: false} expect(9).toBeGreaterThanOrEqual(18)
+  :white_check_mark: throws: [9, 18]
+  :white_check_mark: {pass: true} expect(0.1).toBeLessThan(0.2)
+  :white_check_mark: {pass: false} expect(0.2).toBeLessThan(0.1)
+  :white_check_mark: {pass: true} expect(0.2).toBeGreaterThan(0.1)
+  :white_check_mark: {pass: false} expect(0.1).toBeGreaterThan(0.2)
+  :white_check_mark: {pass: true} expect(0.1).toBeLessThanOrEqual(0.2)
+  :white_check_mark: {pass: false} expect(0.2).toBeLessThanOrEqual(0.1)
+  :white_check_mark: {pass: true} expect(0.2).toBeGreaterThanOrEqual(0.1)
+  :white_check_mark: {pass: false} expect(0.1).toBeGreaterThanOrEqual(0.2)
+  :white_check_mark: throws: [0.1, 0.2]
+  :white_check_mark: can compare BigInt to Numbers
+  :white_check_mark: {pass: true} expect(1n).toBeLessThan(2n)
+  :white_check_mark: {pass: false} expect(2n).toBeLessThan(1n)
+  :white_check_mark: {pass: true} expect(2n).toBeGreaterThan(1n)
+  :white_check_mark: {pass: false} expect(1n).toBeGreaterThan(2n)
+  :white_check_mark: {pass: true} expect(1n).toBeLessThanOrEqual(2n)
+  :white_check_mark: {pass: false} expect(2n).toBeLessThanOrEqual(1n)
+  :white_check_mark: {pass: true} expect(2n).toBeGreaterThanOrEqual(1n)
+  :white_check_mark: {pass: false} expect(1n).toBeGreaterThanOrEqual(2n)
+  :white_check_mark: throws: [1n, 2n]
+  :white_check_mark: {pass: true} expect(17n).toBeLessThan(34n)
+  :white_check_mark: {pass: false} expect(34n).toBeLessThan(17n)
+  :white_check_mark: {pass: true} expect(34n).toBeGreaterThan(17n)
+  :white_check_mark: {pass: false} expect(17n).toBeGreaterThan(34n)
+  :white_check_mark: {pass: true} expect(17n).toBeLessThanOrEqual(34n)
+  :white_check_mark: {pass: false} expect(34n).toBeLessThanOrEqual(17n)
+  :white_check_mark: {pass: true} expect(34n).toBeGreaterThanOrEqual(17n)
+  :white_check_mark: {pass: false} expect(17n).toBeGreaterThanOrEqual(34n)
+  :white_check_mark: throws: [17n, 34n]
+  :white_check_mark: {pass: true} expect(-1).toBeLessThan(2n)
+  :white_check_mark: {pass: false} expect(2n).toBeLessThan(-1)
+  :white_check_mark: {pass: true} expect(2n).toBeGreaterThan(-1)
+  :white_check_mark: {pass: false} expect(-1).toBeGreaterThan(2n)
+  :white_check_mark: {pass: true} expect(-1).toBeLessThanOrEqual(2n)
+  :white_check_mark: {pass: false} expect(2n).toBeLessThanOrEqual(-1)
+  :white_check_mark: {pass: true} expect(2n).toBeGreaterThanOrEqual(-1)
+  :white_check_mark: {pass: false} expect(-1).toBeGreaterThanOrEqual(2n)
+  :white_check_mark: throws: [-1, 2n]
+  :white_check_mark: equal numbers: [1, 1]
+  :white_check_mark: equal numbers: [5e-324, 5e-324]
+  :white_check_mark: equal numbers: [1.7976931348623157e+308, 1.7976931348623157e+308]
+  :white_check_mark: equal numbers: [Infinity, Infinity]
+  :white_check_mark: equal numbers: [-Infinity, -Infinity]
+  :white_check_mark: equal numbers: [1, 1]
+  :white_check_mark: equal numbers: [9007199254740991, 9007199254740991]
+.toContain(), .toContainEqual()
+  :white_check_mark: iterable
+  :white_check_mark: '[1, 2, 3, 4]' contains '1'
+  :white_check_mark: '["a", "b", "c", "d"]' contains '"a"'
+  :white_check_mark: '[undefined, null]' contains 'null'
+  :white_check_mark: '[undefined, null]' contains 'undefined'
+  :white_check_mark: '[Symbol(a)]' contains 'Symbol(a)'
+  :white_check_mark: '"abcdef"' contains '"abc"'
+  :white_check_mark: '"11112111"' contains '"2"'
+  :white_check_mark: 'Set {"abc", "def"}' contains '"abc"'
+  :white_check_mark: '[0, 1]' contains '1'
+  :white_check_mark: '[1n, 2n, 3n, 4n]' contains '1n'
+  :white_check_mark: '[1, 2, 3, 3n, 4]' contains '3n'
+  :white_check_mark: '[1, 2, 3]' does not contain '4'
+  :white_check_mark: '[null, undefined]' does not contain '1'
+  :white_check_mark: '[{}, []]' does not contain '[]'
+  :white_check_mark: '[{}, []]' does not contain '{}'
+  :white_check_mark: '[1n, 2n, 3n]' does not contain '3'
+  :white_check_mark: error cases
+  :white_check_mark: '[1, 2, 3, 4]' contains a value equal to '1'
+  :white_check_mark: '["a", "b", "c", "d"]' contains a value equal to '"a"'
+  :white_check_mark: '[undefined, null]' contains a value equal to 'null'
+  :white_check_mark: '[undefined, null]' contains a value equal to 'undefined'
+  :white_check_mark: '[Symbol(a)]' contains a value equal to 'Symbol(a)'
+  :white_check_mark: '[{"a": "b"}, {"a": "c"}]' contains a value equal to '{"a": "b"}'
+  :white_check_mark: 'Set {1, 2, 3, 4}' contains a value equal to '1'
+  :white_check_mark: '[0, 1]' contains a value equal to '1'
+  :white_check_mark: '[{"a": "b"}, {"a": "c"}]' does not contain a value equal to'{"a": "d"}'
+  :white_check_mark: error cases for toContainEqual
+.toBeCloseTo
+  :white_check_mark: {pass: true} expect(0).toBeCloseTo(0)
+  :white_check_mark: {pass: true} expect(0).toBeCloseTo(0.001)
+  :white_check_mark: {pass: true} expect(1.23).toBeCloseTo(1.229)
+  :white_check_mark: {pass: true} expect(1.23).toBeCloseTo(1.226)
+  :white_check_mark: {pass: true} expect(1.23).toBeCloseTo(1.225)
+  :white_check_mark: {pass: true} expect(1.23).toBeCloseTo(1.234)
+  :white_check_mark: {pass: true} expect(Infinity).toBeCloseTo(Infinity)
+  :white_check_mark: {pass: true} expect(-Infinity).toBeCloseTo(-Infinity)
+  :white_check_mark: {pass: false} expect(0).toBeCloseTo(0.01)
+  :white_check_mark: {pass: false} expect(1).toBeCloseTo(1.23)
+  :white_check_mark: {pass: false} expect(1.23).toBeCloseTo(1.2249999)
+  :white_check_mark: {pass: false} expect(Infinity).toBeCloseTo(-Infinity)
+  :white_check_mark: {pass: false} expect(Infinity).toBeCloseTo(1.23)
+  :white_check_mark: {pass: false} expect(-Infinity).toBeCloseTo(-1.23)
+  :white_check_mark: {pass: false} expect(3.141592e-7).toBeCloseTo(3e-7, 8)
+  :white_check_mark: {pass: false} expect(56789).toBeCloseTo(51234, -4)
+  :white_check_mark: {pass: true} expect(0).toBeCloseTo(0.1, 0)
+  :white_check_mark: {pass: true} expect(0).toBeCloseTo(0.0001, 3)
+  :white_check_mark: {pass: true} expect(0).toBeCloseTo(0.000004, 5)
+  :white_check_mark: {pass: true} expect(2.0000002).toBeCloseTo(2, 5)
+.toBeCloseTo throws: Matcher error
+  :white_check_mark: promise empty isNot false received
+  :white_check_mark: promise empty isNot true expected
+  :white_check_mark: promise rejects isNot false expected
+  :white_check_mark: promise rejects isNot true received
+  :white_check_mark: promise resolves isNot false received
+  :white_check_mark: promise resolves isNot true expected
+.toMatch()
+  :white_check_mark: {pass: true} expect(foo).toMatch(foo)
+  :white_check_mark: {pass: true} expect(Foo bar).toMatch(/^foo/i)
+  :white_check_mark: throws: [bar, foo]
+  :white_check_mark: throws: [bar, /foo/]
+  :white_check_mark: throws if non String actual value passed: [1, "foo"]
+  :white_check_mark: throws if non String actual value passed: [{}, "foo"]
+  :white_check_mark: throws if non String actual value passed: [[], "foo"]
+  :white_check_mark: throws if non String actual value passed: [true, "foo"]
+  :white_check_mark: throws if non String actual value passed: [/foo/i, "foo"]
+  :white_check_mark: throws if non String actual value passed: [[Function anonymous], "foo"]
+  :white_check_mark: throws if non String actual value passed: [undefined, "foo"]
+  :white_check_mark: throws if non String/RegExp expected value passed: ["foo", 1]
+  :white_check_mark: throws if non String/RegExp expected value passed: ["foo", {}]
+  :white_check_mark: throws if non String/RegExp expected value passed: ["foo", []]
+  :white_check_mark: throws if non String/RegExp expected value passed: ["foo", true]
+  :white_check_mark: throws if non String/RegExp expected value passed: ["foo", [Function anonymous]]
+  :white_check_mark: throws if non String/RegExp expected value passed: ["foo", undefined]
+  :white_check_mark: escapes strings properly
+  :white_check_mark: does not maintain RegExp state between calls
+.toHaveLength
+  :white_check_mark: {pass: true} expect([1, 2]).toHaveLength(2)
+  :white_check_mark: {pass: true} expect([]).toHaveLength(0)
+  :white_check_mark: {pass: true} expect(["a", "b"]).toHaveLength(2)
+  :white_check_mark: {pass: true} expect("abc").toHaveLength(3)
+  :white_check_mark: {pass: true} expect("").toHaveLength(0)
+  :white_check_mark: {pass: true} expect([Function anonymous]).toHaveLength(0)
+  :white_check_mark: {pass: false} expect([1, 2]).toHaveLength(3)
+  :white_check_mark: {pass: false} expect([]).toHaveLength(1)
+  :white_check_mark: {pass: false} expect(["a", "b"]).toHaveLength(99)
+  :white_check_mark: {pass: false} expect("abc").toHaveLength(66)
+  :white_check_mark: {pass: false} expect("").toHaveLength(1)
+  :white_check_mark: error cases
+.toHaveLength matcher error expected length
+  :white_check_mark: not number
+  :white_check_mark: number Infinity
+  :white_check_mark: number NaN
+  :white_check_mark: number float
+  :white_check_mark: number negative integer
+.toHaveProperty()
+  :white_check_mark: {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 1)
+  :white_check_mark: {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 1)
+  :white_check_mark: {pass: true} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 1)
+  :white_check_mark: {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1', 2)
+  :white_check_mark: {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1', Any<Number>)
+  :white_check_mark: {pass: true} expect({"a": 0}).toHaveProperty('a', 0)
+  :white_check_mark: {pass: true} expect({"a": {"b": undefined}}).toHaveProperty('a.b', undefined)
+  :white_check_mark: {pass: true} expect({"a": {}}).toHaveProperty('a.b', undefined)
+  :white_check_mark: {pass: true} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 5})
+  :white_check_mark: {pass: true} expect({"property": 1}).toHaveProperty('property', 1)
+  :white_check_mark: {pass: true} expect({}).toHaveProperty('a', undefined)
+  :white_check_mark: {pass: true} expect({}).toHaveProperty('b', "b")
+  :white_check_mark: {pass: true} expect({}).toHaveProperty('setter', undefined)
+  :white_check_mark: {pass: true} expect({"val": true}).toHaveProperty('a', undefined)
+  :white_check_mark: {pass: true} expect({"val": true}).toHaveProperty('c', "c")
+  :white_check_mark: {pass: true} expect({"val": true}).toHaveProperty('val', true)
+  :white_check_mark: {pass: true} expect({"nodeName": "DIV"}).toHaveProperty('nodeType', 1)
+  :white_check_mark: {pass: true} expect("").toHaveProperty('length', 0)
+  :white_check_mark: {pass: true} expect([Function memoized]).toHaveProperty('memo', [])
+  :white_check_mark: {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.ttt.d', 1)
+  :white_check_mark: {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 2)
+  :white_check_mark: {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2)
+  :white_check_mark: {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2)
+  :white_check_mark: {pass: false} expect({"children": ["\"That cartoon\""], "props": null, "type": "p"}).toHaveProperty('children,0', "\"That cat cartoon\"")
+  :white_check_mark: {pass: false} expect({"children": ["Roses are red.
+Violets are blue.
+Testing with Jest is good for you."], "props": null, "type": "pre"}).toHaveProperty('children,0', "Roses are red, violets are blue.
+Testing with Jest
+Is good for you.")
+  :white_check_mark: {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 2)
+  :white_check_mark: {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d', 1)
+  :white_check_mark: {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.d', 5)
+  :white_check_mark: {pass: false} expect({}).toHaveProperty('a', "test")
+  :white_check_mark: {pass: false} expect({"a": {"b": 3}}).toHaveProperty('a.b', undefined)
+  :white_check_mark: {pass: false} expect(1).toHaveProperty('a.b.c', "test")
+  :white_check_mark: {pass: false} expect("abc").toHaveProperty('a.b.c', {"a": 5})
+  :white_check_mark: {pass: false} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 4})
+  :white_check_mark: {pass: false} expect({}).toHaveProperty('a', "a")
+  :white_check_mark: {pass: false} expect({}).toHaveProperty('b', undefined)
+  :white_check_mark: {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d')
+  :white_check_mark: {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d')
+  :white_check_mark: {pass: true} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d')
+  :white_check_mark: {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1')
+  :white_check_mark: {pass: true} expect({"a": 0}).toHaveProperty('a')
+  :white_check_mark: {pass: true} expect({"a": {"b": undefined}}).toHaveProperty('a.b')
+  :white_check_mark: {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d')
+  :white_check_mark: {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.d')
+  :white_check_mark: {pass: false} expect({}).toHaveProperty('a')
+  :white_check_mark: {pass: false} expect(1).toHaveProperty('a.b.c')
+  :white_check_mark: {pass: false} expect("abc").toHaveProperty('a.b.c')
+  :white_check_mark: {pass: false} expect(false).toHaveProperty('key')
+  :white_check_mark: {pass: false} expect(0).toHaveProperty('key')
+  :white_check_mark: {pass: false} expect("").toHaveProperty('key')
+  :white_check_mark: {pass: false} expect(Symbol()).toHaveProperty('key')
+  :white_check_mark: {pass: false} expect({"key": 1}).toHaveProperty('not')
+  :white_check_mark: {error} expect(null).toHaveProperty('a.b')
+  :white_check_mark: {error} expect(undefined).toHaveProperty('a')
+  :white_check_mark: {error} expect({"a": {"b": {}}}).toHaveProperty('undefined')
+  :white_check_mark: {error} expect({"a": {"b": {}}}).toHaveProperty('null')
+  :white_check_mark: {error} expect({"a": {"b": {}}}).toHaveProperty('1')
+  :white_check_mark: {error} expect({}).toHaveProperty('')
+toMatchObject() circular references simple circular references
+  :white_check_mark: {pass: true} expect({"a": "hello", "ref": [Circular]}).toMatchObject({})
+  :white_check_mark: {pass: true} expect({"a": "hello", "ref": [Circular]}).toMatchObject({"a": "hello", "ref": [Circular]})
+  :white_check_mark: {pass: false} expect({}).toMatchObject({"a": "hello", "ref": [Circular]})
+  :white_check_mark: {pass: false} expect({"a": "hello", "ref": [Circular]}).toMatchObject({"a": "world", "ref": [Circular]})
+  :white_check_mark: {pass: false} expect({"ref": "not a ref"}).toMatchObject({"a": "hello", "ref": [Circular]})
+toMatchObject() circular references transitive circular references
+  :white_check_mark: {pass: true} expect({"a": "hello", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({})
+  :white_check_mark: {pass: true} expect({"a": "hello", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}})
+  :white_check_mark: {pass: false} expect({}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}})
+  :white_check_mark: {pass: false} expect({"a": "world", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}})
+  :white_check_mark: {pass: false} expect({"nestedObj": {"parentObj": "not the parent ref"}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}})
+toMatchObject()
+  :white_check_mark: {pass: true} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b"})
+  :white_check_mark: {pass: true} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b", "c": "d"})
+  :white_check_mark: {pass: true} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"a": "b", "t": {"z": "z"}})
+  :white_check_mark: {pass: true} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"t": {"x": {"r": "r"}}})
+  :white_check_mark: {pass: true} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4, 5]})
+  :white_check_mark: {pass: true} expect({"a": [3, 4, 5, "v"], "b": "b"}).toMatchObject({"a": [3, 4, 5, "v"]})
+  :white_check_mark: {pass: true} expect({"a": 1, "c": 2}).toMatchObject({"a": Any<Number>})
+  :white_check_mark: {pass: true} expect({"a": {"x": "x", "y": "y"}}).toMatchObject({"a": {"x": Any<String>}})
+  :white_check_mark: {pass: true} expect(Set {1, 2}).toMatchObject(Set {1, 2})
+  :white_check_mark: {pass: true} expect(Set {1, 2}).toMatchObject(Set {2, 1})
+  :white_check_mark: {pass: true} expect(2015-11-30T00:00:00.000Z).toMatchObject(2015-11-30T00:00:00.000Z)
+  :white_check_mark: {pass: true} expect({"a": 2015-11-30T00:00:00.000Z, "b": "b"}).toMatchObject({"a": 2015-11-30T00:00:00.000Z})
+  :white_check_mark: {pass: true} expect({"a": null, "b": "b"}).toMatchObject({"a": null})
+  :white_check_mark: {pass: true} expect({"a": undefined, "b": "b"}).toMatchObject({"a": undefined})
+  :white_check_mark: {pass: true} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "a"}]})
+  :white_check_mark: {pass: true} expect([1, 2]).toMatchObject([1, 2])
+  :white_check_mark: {pass: true} expect({"a": undefined}).toMatchObject({"a": undefined})
+  :white_check_mark: {pass: true} expect([]).toMatchObject([])
+  :white_check_mark: {pass: true} expect([Error: foo]).toMatchObject([Error: foo])
+  :white_check_mark: {pass: true} expect([Error: bar]).toMatchObject({"message": "bar"})
+  :white_check_mark: {pass: true} expect({}).toMatchObject({"a": undefined, "b": "b"})
+  :white_check_mark: {pass: true} expect({"a": "b"}).toMatchObject({"a": "b"})
+  :white_check_mark: {pass: true} expect({"a": "b", "c": "d", Symbol(jest): "jest"}).toMatchObject({"a": "b", Symbol(jest): "jest"})
+  :white_check_mark: {pass: true} expect({"a": "b", "c": "d", Symbol(jest): "jest"}).toMatchObject({"a": "b", "c": "d", Symbol(jest): "jest"})
+  :white_check_mark: {pass: true} expect({}).toMatchObject({"a": undefined, "b": "b", "c": "c"})
+  :white_check_mark: {pass: true} expect({}).toMatchObject({"d": 4})
+  :white_check_mark: {pass: true} expect({"a": "b", "toString": [Function toString]}).toMatchObject({"toString": Any<Function>})
+  :white_check_mark: {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"e": "b"})
+  :white_check_mark: {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b!", "c": "d"})
+  :white_check_mark: {pass: false} expect({"a": "a", "c": "d"}).toMatchObject({"a": Any<Number>})
+  :white_check_mark: {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"a": "b", "t": {"z": [3]}})
+  :white_check_mark: {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"t": {"l": {"r": "r"}}})
+  :white_check_mark: {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4, 5, 6]})
+  :white_check_mark: {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4]})
+  :white_check_mark: {pass: false} expect({"a": [3, 4, "v"], "b": "b"}).toMatchObject({"a": ["v"]})
+  :white_check_mark: {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": {"b": 4}})
+  :white_check_mark: {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": {"b": Any<String>}})
+  :white_check_mark: {pass: false} expect([1, 2]).toMatchObject([1, 3])
+  :white_check_mark: {pass: false} expect([0]).toMatchObject([-0])
+  :white_check_mark: {pass: false} expect(Set {1, 2}).toMatchObject(Set {2})
+  :white_check_mark: {pass: false} expect(2015-11-30T00:00:00.000Z).toMatchObject(2015-10-10T00:00:00.000Z)
+  :white_check_mark: {pass: false} expect({"a": 2015-11-30T00:00:00.000Z, "b": "b"}).toMatchObject({"a": 2015-10-10T00:00:00.000Z})
+  :white_check_mark: {pass: false} expect({"a": null, "b": "b"}).toMatchObject({"a": "4"})
+  :white_check_mark: {pass: false} expect({"a": null, "b": "b"}).toMatchObject({"a": undefined})
+  :white_check_mark: {pass: false} expect({"a": undefined}).toMatchObject({"a": null})
+  :white_check_mark: {pass: false} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "c"}]})
+  :white_check_mark: {pass: false} expect({"a": 1, "b": 1, "c": 1, "d": {"e": {"f": 555}}}).toMatchObject({"d": {"e": {"f": 222}}})
+  :white_check_mark: {pass: false} expect({}).toMatchObject({"a": undefined})
+  :white_check_mark: {pass: false} expect([1, 2, 3]).toMatchObject([2, 3, 1])
+  :white_check_mark: {pass: false} expect([1, 2, 3]).toMatchObject([1, 2, 2])
+  :white_check_mark: {pass: false} expect([Error: foo]).toMatchObject([Error: bar])
+  :white_check_mark: {pass: false} expect({"a": "b"}).toMatchObject({"c": "d"})
+  :white_check_mark: {pass: false} expect({"a": "b", "c": "d", Symbol(jest): "jest"}).toMatchObject({"a": "c", Symbol(jest): Any<String>})
+  :white_check_mark: {pass: false} expect({"a": "b"}).toMatchObject({"toString": Any<Function>})
+  :white_check_mark: throws expect(null).toMatchObject({})
+  :white_check_mark: throws expect(4).toMatchObject({})
+  :white_check_mark: throws expect("44").toMatchObject({})
+  :white_check_mark: throws expect(true).toMatchObject({})
+  :white_check_mark: throws expect(undefined).toMatchObject({})
+  :white_check_mark: throws expect({}).toMatchObject(null)
+  :white_check_mark: throws expect({}).toMatchObject(4)
+  :white_check_mark: throws expect({}).toMatchObject("some string")
+  :white_check_mark: throws expect({}).toMatchObject(true)
+  :white_check_mark: throws expect({}).toMatchObject(undefined)
+  :white_check_mark: does not match properties up in the prototype chain
+```
+### :white_check_mark: <a id="user-content-r0s228" href="#r0s228">packages/expect/src/__tests__/spyMatchers.test.ts</a>
+```
+toBeCalled
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: passes when called
+  :white_check_mark: .not passes when called
+  :white_check_mark: fails with any argument passed
+  :white_check_mark: .not fails with any argument passed
+  :white_check_mark: includes the custom mock name in the error message
+toHaveBeenCalled
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: passes when called
+  :white_check_mark: .not passes when called
+  :white_check_mark: fails with any argument passed
+  :white_check_mark: .not fails with any argument passed
+  :white_check_mark: includes the custom mock name in the error message
+toBeCalledTimes
+  :white_check_mark: .not works only on spies or jest.fn
+  :white_check_mark: only accepts a number argument
+  :white_check_mark: .not only accepts a number argument
+  :white_check_mark: passes if function called equal to expected times
+  :white_check_mark: .not passes if function called more than expected times
+  :white_check_mark: .not passes if function called less than expected times
+  :white_check_mark: includes the custom mock name in the error message
+toHaveBeenCalledTimes
+  :white_check_mark: .not works only on spies or jest.fn
+  :white_check_mark: only accepts a number argument
+  :white_check_mark: .not only accepts a number argument
+  :white_check_mark: passes if function called equal to expected times
+  :white_check_mark: .not passes if function called more than expected times
+  :white_check_mark: .not passes if function called less than expected times
+  :white_check_mark: includes the custom mock name in the error message
+lastCalledWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with arguments that don't match
+  :white_check_mark: works with arguments that match
+  :white_check_mark: works with trailing undefined arguments
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects
+  :white_check_mark: works with many arguments
+  :white_check_mark: works with many arguments that don't match
+  :white_check_mark: includes the custom mock name in the error message
+toHaveBeenLastCalledWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with arguments that don't match
+  :white_check_mark: works with arguments that match
+  :white_check_mark: works with trailing undefined arguments
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects
+  :white_check_mark: works with many arguments
+  :white_check_mark: works with many arguments that don't match
+  :white_check_mark: includes the custom mock name in the error message
+nthCalledWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with arguments that don't match
+  :white_check_mark: works with arguments that match
+  :white_check_mark: works with trailing undefined arguments
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects
+  :white_check_mark: works with three calls
+  :white_check_mark: positive throw matcher error for n that is not positive integer
+  :white_check_mark: positive throw matcher error for n that is not integer
+  :white_check_mark: negative throw matcher error for n that is not integer
+  :white_check_mark: includes the custom mock name in the error message
+toHaveBeenNthCalledWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with arguments that don't match
+  :white_check_mark: works with arguments that match
+  :white_check_mark: works with trailing undefined arguments
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects
+  :white_check_mark: works with three calls
+  :white_check_mark: positive throw matcher error for n that is not positive integer
+  :white_check_mark: positive throw matcher error for n that is not integer
+  :white_check_mark: negative throw matcher error for n that is not integer
+  :white_check_mark: includes the custom mock name in the error message
+toBeCalledWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with arguments that don't match
+  :white_check_mark: works with arguments that match
+  :white_check_mark: works with trailing undefined arguments
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects
+  :white_check_mark: works with many arguments
+  :white_check_mark: works with many arguments that don't match
+  :white_check_mark: includes the custom mock name in the error message
+toHaveBeenCalledWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with arguments that don't match
+  :white_check_mark: works with arguments that match
+  :white_check_mark: works with trailing undefined arguments
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects
+  :white_check_mark: works with many arguments
+  :white_check_mark: works with many arguments that don't match
+  :white_check_mark: includes the custom mock name in the error message
+toReturn
+  :white_check_mark: .not works only on jest.fn
+  :white_check_mark: throw matcher error if received is spy
+  :white_check_mark: passes when returned
+  :white_check_mark: passes when undefined is returned
+  :white_check_mark: passes when at least one call does not throw
+  :white_check_mark: .not passes when not returned
+  :white_check_mark: .not passes when all calls throw
+  :white_check_mark: .not passes when a call throws undefined
+  :white_check_mark: fails with any argument passed
+  :white_check_mark: .not fails with any argument passed
+  :white_check_mark: includes the custom mock name in the error message
+  :white_check_mark: incomplete recursive calls are handled properly
+toHaveReturned
+  :white_check_mark: .not works only on jest.fn
+  :white_check_mark: throw matcher error if received is spy
+  :white_check_mark: passes when returned
+  :white_check_mark: passes when undefined is returned
+  :white_check_mark: passes when at least one call does not throw
+  :white_check_mark: .not passes when not returned
+  :white_check_mark: .not passes when all calls throw
+  :white_check_mark: .not passes when a call throws undefined
+  :white_check_mark: fails with any argument passed
+  :white_check_mark: .not fails with any argument passed
+  :white_check_mark: includes the custom mock name in the error message
+  :white_check_mark: incomplete recursive calls are handled properly
+toReturnTimes
+  :white_check_mark: throw matcher error if received is spy
+  :white_check_mark: only accepts a number argument
+  :white_check_mark: .not only accepts a number argument
+  :white_check_mark: passes if function returned equal to expected times
+  :white_check_mark: calls that return undefined are counted as returns
+  :white_check_mark: .not passes if function returned more than expected times
+  :white_check_mark: .not passes if function called less than expected times
+  :white_check_mark: calls that throw are not counted
+  :white_check_mark: calls that throw undefined are not counted
+  :white_check_mark: includes the custom mock name in the error message
+  :white_check_mark: incomplete recursive calls are handled properly
+toHaveReturnedTimes
+  :white_check_mark: throw matcher error if received is spy
+  :white_check_mark: only accepts a number argument
+  :white_check_mark: .not only accepts a number argument
+  :white_check_mark: passes if function returned equal to expected times
+  :white_check_mark: calls that return undefined are counted as returns
+  :white_check_mark: .not passes if function returned more than expected times
+  :white_check_mark: .not passes if function called less than expected times
+  :white_check_mark: calls that throw are not counted
+  :white_check_mark: calls that throw undefined are not counted
+  :white_check_mark: includes the custom mock name in the error message
+  :white_check_mark: incomplete recursive calls are handled properly
+lastReturnedWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with argument that does not match
+  :white_check_mark: works with argument that does match
+  :white_check_mark: works with undefined
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects directly created
+  :white_check_mark: works with Immutable.js objects indirectly created
+  :white_check_mark: a call that throws is not considered to have returned
+  :white_check_mark: a call that throws undefined is not considered to have returned
+  :white_check_mark: includes the custom mock name in the error message
+lastReturnedWith lastReturnedWith
+  :white_check_mark: works with three calls
+  :white_check_mark: incomplete recursive calls are handled properly
+toHaveLastReturnedWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with argument that does not match
+  :white_check_mark: works with argument that does match
+  :white_check_mark: works with undefined
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects directly created
+  :white_check_mark: works with Immutable.js objects indirectly created
+  :white_check_mark: a call that throws is not considered to have returned
+  :white_check_mark: a call that throws undefined is not considered to have returned
+  :white_check_mark: includes the custom mock name in the error message
+toHaveLastReturnedWith lastReturnedWith
+  :white_check_mark: works with three calls
+  :white_check_mark: incomplete recursive calls are handled properly
+nthReturnedWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with argument that does not match
+  :white_check_mark: works with argument that does match
+  :white_check_mark: works with undefined
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects directly created
+  :white_check_mark: works with Immutable.js objects indirectly created
+  :white_check_mark: a call that throws is not considered to have returned
+  :white_check_mark: a call that throws undefined is not considered to have returned
+  :white_check_mark: includes the custom mock name in the error message
+nthReturnedWith nthReturnedWith
+  :white_check_mark: works with three calls
+  :white_check_mark: should replace 1st, 2nd, 3rd with first, second, third
+  :white_check_mark: positive throw matcher error for n that is not positive integer
+  :white_check_mark: should reject nth value greater than number of calls
+  :white_check_mark: positive throw matcher error for n that is not integer
+  :white_check_mark: negative throw matcher error for n that is not number
+  :white_check_mark: incomplete recursive calls are handled properly
+toHaveNthReturnedWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with argument that does not match
+  :white_check_mark: works with argument that does match
+  :white_check_mark: works with undefined
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects directly created
+  :white_check_mark: works with Immutable.js objects indirectly created
+  :white_check_mark: a call that throws is not considered to have returned
+  :white_check_mark: a call that throws undefined is not considered to have returned
+  :white_check_mark: includes the custom mock name in the error message
+toHaveNthReturnedWith nthReturnedWith
+  :white_check_mark: works with three calls
+  :white_check_mark: should replace 1st, 2nd, 3rd with first, second, third
+  :white_check_mark: positive throw matcher error for n that is not positive integer
+  :white_check_mark: should reject nth value greater than number of calls
+  :white_check_mark: positive throw matcher error for n that is not integer
+  :white_check_mark: negative throw matcher error for n that is not number
+  :white_check_mark: incomplete recursive calls are handled properly
+toReturnWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with argument that does not match
+  :white_check_mark: works with argument that does match
+  :white_check_mark: works with undefined
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects directly created
+  :white_check_mark: works with Immutable.js objects indirectly created
+  :white_check_mark: a call that throws is not considered to have returned
+  :white_check_mark: a call that throws undefined is not considered to have returned
+  :white_check_mark: includes the custom mock name in the error message
+toReturnWith returnedWith
+  :white_check_mark: works with more calls than the limit
+  :white_check_mark: incomplete recursive calls are handled properly
+toHaveReturnedWith
+  :white_check_mark: works only on spies or jest.fn
+  :white_check_mark: works when not called
+  :white_check_mark: works with no arguments
+  :white_check_mark: works with argument that does not match
+  :white_check_mark: works with argument that does match
+  :white_check_mark: works with undefined
+  :white_check_mark: works with Map
+  :white_check_mark: works with Set
+  :white_check_mark: works with Immutable.js objects directly created
+  :white_check_mark: works with Immutable.js objects indirectly created
+  :white_check_mark: a call that throws is not considered to have returned
+  :white_check_mark: a call that throws undefined is not considered to have returned
+  :white_check_mark: includes the custom mock name in the error message
+toHaveReturnedWith returnedWith
+  :white_check_mark: works with more calls than the limit
+  :white_check_mark: incomplete recursive calls are handled properly
+```
+### :white_check_mark: <a id="user-content-r0s229" href="#r0s229">packages/expect/src/__tests__/stacktrace.test.ts</a>
+```
+:white_check_mark: stack trace points to correct location when using matchers
+:white_check_mark: stack trace points to correct location when using nested matchers
+:white_check_mark: stack trace points to correct location when throwing from a custom matcher
+```
+### :white_check_mark: <a id="user-content-r0s230" href="#r0s230">packages/expect/src/__tests__/symbolInObjects.test.ts</a>
+```
+Symbol in objects
+  :white_check_mark: should compare objects with Symbol keys
+  :white_check_mark: should compare objects with mixed keys and Symbol
+  :white_check_mark: should compare objects with different Symbol keys
+```
+### :white_check_mark: <a id="user-content-r0s231" href="#r0s231">packages/expect/src/__tests__/toEqual-dom.test.ts</a>
+```
+toEqual duck type Text
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toEqual duck type Element
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toEqual duck type Fragment
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toEqual document createTextNode
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toEqual document createElement
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toEqual document createDocumentFragment
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+```
+### :white_check_mark: <a id="user-content-r0s232" href="#r0s232">packages/expect/src/__tests__/toThrowMatchers.test.ts</a>
+```
+toThrowError
+  :white_check_mark: to throw or not to throw
+  :white_check_mark: invalid arguments
+  :white_check_mark: invalid actual
+toThrowError substring
+  :white_check_mark: passes
+  :white_check_mark: did not throw at all
+  :white_check_mark: threw, but message did not match (error)
+  :white_check_mark: threw, but message did not match (non-error falsey)
+  :white_check_mark: properly escapes strings when matching against errors
+  :white_check_mark: threw, but message should not match (error)
+  :white_check_mark: threw, but message should not match (non-error truthy)
+toThrowError regexp
+  :white_check_mark: passes
+  :white_check_mark: did not throw at all
+  :white_check_mark: threw, but message did not match (error)
+  :white_check_mark: threw, but message did not match (non-error falsey)
+  :white_check_mark: threw, but message should not match (error)
+  :white_check_mark: threw, but message should not match (non-error truthy)
+toThrowError error class
+  :white_check_mark: passes
+  :white_check_mark: did not throw at all
+  :white_check_mark: threw, but class did not match (error)
+  :white_check_mark: threw, but class did not match (non-error falsey)
+  :white_check_mark: threw, but class should not match (error)
+  :white_check_mark: threw, but class should not match (error subclass)
+  :white_check_mark: threw, but class should not match (error subsubclass)
+toThrowError error-message pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrowError error-message fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+  :white_check_mark: multiline diff highlight incorrect expected space
+toThrowError asymmetric any-Class pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrowError asymmetric any-Class fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrowError asymmetric anything pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrowError asymmetric anything fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrowError asymmetric no-symbol pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrowError asymmetric no-symbol fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrowError asymmetric objectContaining pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrowError asymmetric objectContaining fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrowError promise/async throws if Error-like object is returned
+  :white_check_mark: passes
+  :white_check_mark: did not throw at all
+  :white_check_mark: threw, but class did not match
+  :white_check_mark: threw, but should not have
+toThrowError expected is undefined
+  :white_check_mark: threw, but should not have (non-error falsey)
+toThrow
+  :white_check_mark: to throw or not to throw
+  :white_check_mark: invalid arguments
+  :white_check_mark: invalid actual
+toThrow substring
+  :white_check_mark: passes
+  :white_check_mark: did not throw at all
+  :white_check_mark: threw, but message did not match (error)
+  :white_check_mark: threw, but message did not match (non-error falsey)
+  :white_check_mark: properly escapes strings when matching against errors
+  :white_check_mark: threw, but message should not match (error)
+  :white_check_mark: threw, but message should not match (non-error truthy)
+toThrow regexp
+  :white_check_mark: passes
+  :white_check_mark: did not throw at all
+  :white_check_mark: threw, but message did not match (error)
+  :white_check_mark: threw, but message did not match (non-error falsey)
+  :white_check_mark: threw, but message should not match (error)
+  :white_check_mark: threw, but message should not match (non-error truthy)
+toThrow error class
+  :white_check_mark: passes
+  :white_check_mark: did not throw at all
+  :white_check_mark: threw, but class did not match (error)
+  :white_check_mark: threw, but class did not match (non-error falsey)
+  :white_check_mark: threw, but class should not match (error)
+  :white_check_mark: threw, but class should not match (error subclass)
+  :white_check_mark: threw, but class should not match (error subsubclass)
+toThrow error-message pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrow error-message fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+  :white_check_mark: multiline diff highlight incorrect expected space
+toThrow asymmetric any-Class pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrow asymmetric any-Class fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrow asymmetric anything pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrow asymmetric anything fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrow asymmetric no-symbol pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrow asymmetric no-symbol fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrow asymmetric objectContaining pass
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrow asymmetric objectContaining fail
+  :white_check_mark: isNot false
+  :white_check_mark: isNot true
+toThrow promise/async throws if Error-like object is returned
+  :white_check_mark: passes
+  :white_check_mark: did not throw at all
+  :white_check_mark: threw, but class did not match
+  :white_check_mark: threw, but should not have
+toThrow expected is undefined
+  :white_check_mark: threw, but should not have (non-error falsey)
+```
+### :white_check_mark: <a id="user-content-r0s233" href="#r0s233">packages/expect/src/__tests__/utils.test.ts</a>
+```
+getPath()
+  :white_check_mark: property exists
+  :white_check_mark: property doesnt exist
+  :white_check_mark: property exist but undefined
+  :white_check_mark: property is a getter on class instance
+  :white_check_mark: property is inherited
+  :white_check_mark: path breaks
+  :white_check_mark: empty object at the end
+getObjectSubset
+  :white_check_mark: expect(getObjectSubset({"a": "b", "c": "d"}, {"a": "d"})).toEqual({"a": "b"})
+  :white_check_mark: expect(getObjectSubset({"a": [1, 2], "b": "b"}, {"a": [3, 4]})).toEqual({"a": [1, 2]})
+  :white_check_mark: expect(getObjectSubset([{"a": "b", "c": "d"}], [{"a": "z"}])).toEqual([{"a": "b"}])
+  :white_check_mark: expect(getObjectSubset([1, 2], [1, 2, 3])).toEqual([1, 2])
+  :white_check_mark: expect(getObjectSubset({"a": [1]}, {"a": [1, 2]})).toEqual({"a": [1]})
+  :white_check_mark: expect(getObjectSubset(2015-11-30T00:00:00.000Z, 2016-12-30T00:00:00.000Z)).toEqual(2015-11-30T00:00:00.000Z)
+getObjectSubset returns the object instance if the subset has no extra properties
+  :white_check_mark: Date
+getObjectSubset returns the subset instance if its property values are equal
+  :white_check_mark: Object
+getObjectSubset returns the subset instance if its property values are equal Uint8Array
+  :white_check_mark: expected
+  :white_check_mark: received
+getObjectSubset calculating subsets of objects with circular references
+  :white_check_mark: simple circular references
+  :white_check_mark: transitive circular references
+emptyObject()
+  :white_check_mark: matches an empty object
+  :white_check_mark: does not match an object with keys
+  :white_check_mark: does not match a non-object
+subsetEquality()
+  :white_check_mark: matching object returns true
+  :white_check_mark: object without keys is undefined
+  :white_check_mark: objects to not match
+  :white_check_mark: null does not return errors
+  :white_check_mark: undefined does not return errors
+subsetEquality() matching subsets with circular references
+  :white_check_mark: simple circular references
+  :white_check_mark: referenced object on same level should not regarded as circular reference
+  :white_check_mark: transitive circular references
+iterableEquality
+  :white_check_mark: returns true when given circular iterators
+  :white_check_mark: returns true when given circular Set
+  :white_check_mark: returns true when given nested Sets
+  :white_check_mark: returns false when given inequal set within a set
+  :white_check_mark: returns false when given inequal map within a set
+  :white_check_mark: returns false when given inequal set within a map
+  :white_check_mark: returns true when given circular Set shape
+  :white_check_mark: returns true when given circular key in Map
+  :white_check_mark: returns true when given nested Maps
+  :white_check_mark: returns true when given circular key and value in Map
+  :white_check_mark: returns true when given circular value in Map
+```
+### :white_check_mark: <a id="user-content-r0s234" href="#r0s234">packages/jest-circus/src/__tests__/afterAll.test.ts</a>
+```
+:white_check_mark: tests are not marked done until their parent afterAll runs
+:white_check_mark: describe block cannot have hooks and no tests
+:white_check_mark: describe block _can_ have hooks if a child describe block has tests
+:white_check_mark: describe block hooks must not run if describe block is skipped
+:white_check_mark: child tests marked with todo should not run if describe block is skipped
+:white_check_mark: child tests marked with only should not run if describe block is skipped
+```
+### :white_check_mark: <a id="user-content-r0s235" href="#r0s235">packages/jest-circus/src/__tests__/baseTest.test.ts</a>
+```
+:white_check_mark: simple test
+:white_check_mark: failures
+```
+### :white_check_mark: <a id="user-content-r0s236" href="#r0s236">packages/jest-circus/src/__tests__/circusItTestError.test.ts</a>
+```
+test/it error throwing
+  :white_check_mark: it doesn't throw an error with valid arguments
+  :white_check_mark: it throws error with missing callback function
+  :white_check_mark: it throws an error when first argument isn't a string
+  :white_check_mark: it throws an error when callback function is not a function
+  :white_check_mark: test doesn't throw an error with valid arguments
+  :white_check_mark: test throws error with missing callback function
+  :white_check_mark: test throws an error when first argument isn't a string
+  :white_check_mark: test throws an error when callback function is not a function
+```
+### :white_check_mark: <a id="user-content-r0s237" href="#r0s237">packages/jest-circus/src/__tests__/circusItTodoTestError.test.ts</a>
+```
+test/it.todo error throwing
+  :white_check_mark: todo throws error when given no arguments
+  :white_check_mark: todo throws error when given more than one argument
+  :white_check_mark: todo throws error when given none string description
+```
+### :white_check_mark: <a id="user-content-r0s238" href="#r0s238">packages/jest-circus/src/__tests__/hooks.test.ts</a>
+```
+:white_check_mark: beforeEach is executed before each test in current/child describe blocks
+:white_check_mark: multiple before each hooks in one describe are executed in the right order
+:white_check_mark: beforeAll is exectued correctly
+```
+### :white_check_mark: <a id="user-content-r0s239" href="#r0s239">packages/jest-circus/src/__tests__/hooksError.test.ts</a>
+```
+beforeEach hooks error throwing
+  :white_check_mark: beforeEach throws an error when "String" is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when 1 is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when [] is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when {} is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when Symbol(hello) is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when true is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when null is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when undefined is provided as a first argument to it
+beforeAll hooks error throwing
+  :white_check_mark: beforeAll throws an error when "String" is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when 1 is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when [] is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when {} is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when Symbol(hello) is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when true is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when null is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when undefined is provided as a first argument to it
+afterEach hooks error throwing
+  :white_check_mark: afterEach throws an error when "String" is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when 1 is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when [] is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when {} is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when Symbol(hello) is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when true is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when null is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when undefined is provided as a first argument to it
+afterAll hooks error throwing
+  :white_check_mark: afterAll throws an error when "String" is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when 1 is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when [] is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when {} is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when Symbol(hello) is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when true is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when null is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when undefined is provided as a first argument to it
+```
+### :white_check_mark: <a id="user-content-r0s240" href="#r0s240">packages/jest-cli/src/__tests__/cli/args.test.ts</a>
+```
+check
+  :white_check_mark: returns true if the arguments are valid
+  :white_check_mark: raises an exception if runInBand and maxWorkers are both specified
+  :white_check_mark: raises an exception if onlyChanged and watchAll are both specified
+  :white_check_mark: raises an exception if onlyFailures and watchAll are both specified
+  :white_check_mark: raises an exception when lastCommit and watchAll are both specified
+  :white_check_mark: raises an exception if findRelatedTests is specified with no file paths
+  :white_check_mark: raises an exception if maxWorkers is specified with no number
+  :white_check_mark: allows maxWorkers to be a %
+  :white_check_mark: allows using "js" file for --config option
+  :white_check_mark: allows using "ts" file for --config option
+  :white_check_mark: allows using "mjs" file for --config option
+  :white_check_mark: allows using "cjs" file for --config option
+  :white_check_mark: allows using "json" file for --config option
+  :white_check_mark: raises an exception if selectProjects is not provided any project names
+  :white_check_mark: raises an exception if config is not a valid JSON string
+  :white_check_mark: raises an exception if config is not a supported file type
+buildArgv
+  :white_check_mark: should return only camelcased args
+```
+### :white_check_mark: <a id="user-content-r0s241" href="#r0s241">packages/jest-cli/src/init/__tests__/init.test.js</a>
+```
+init project with package.json and no jest config all questions answered with answer: "No"
+  :white_check_mark: should return the default configuration (an empty config)
+  :white_check_mark: should generate empty config with mjs extension
+init project with package.json and no jest config some questions answered with answer: "Yes"
+  :white_check_mark: should create configuration for {clearMocks: true}
+  :white_check_mark: should create configuration for {coverage: true}
+  :white_check_mark: should create configuration for {coverageProvider: "babel"}
+  :white_check_mark: should create configuration for {coverageProvider: "v8"}
+  :white_check_mark: should create configuration for {environment: "jsdom"}
+  :white_check_mark: should create configuration for {environment: "node"}
+  :white_check_mark: should create package.json with configured test command when {scripts: true}
+init no package json
+  :white_check_mark: should throw an error if there is no package.json file
+init has-jest-config-file-js ask the user whether to override config or not
+  :white_check_mark: user answered with "Yes"
+  :white_check_mark: user answered with "No"
+init has-jest-config-file-ts ask the user whether to override config or not
+  :white_check_mark: user answered with "Yes"
+  :white_check_mark: user answered with "No"
+init has-jest-config-file-mjs ask the user whether to override config or not
+  :white_check_mark: user answered with "Yes"
+  :white_check_mark: user answered with "No"
+init has-jest-config-file-cjs ask the user whether to override config or not
+  :white_check_mark: user answered with "Yes"
+  :white_check_mark: user answered with "No"
+init has-jest-config-file-json ask the user whether to override config or not
+  :white_check_mark: user answered with "Yes"
+  :white_check_mark: user answered with "No"
+init project using jest.config.ts ask the user whether he wants to use Typescript or not
+  :white_check_mark: user answered with "Yes"
+  :white_check_mark: user answered with "No"
+init has jest config in package.json
+  :white_check_mark: should ask the user whether to override config or not
+init already has "jest" in packageJson.scripts.test
+  :white_check_mark: should not ask "test script question"
+```
+### :white_check_mark: <a id="user-content-r0s242" href="#r0s242">packages/jest-cli/src/init/__tests__/modifyPackageJson.test.ts</a>
+```
+:white_check_mark: should remove jest config if exists
+:white_check_mark: should add test script when there are no scripts
+:white_check_mark: should add test script when there are scripts
+:white_check_mark: should not add test script when { shouldModifyScripts: false }
+```
+### :white_check_mark: <a id="user-content-r0s243" href="#r0s243">packages/jest-config/src/__tests__/Defaults.test.ts</a>
+```
+:white_check_mark: get configuration defaults
+```
+### :white_check_mark: <a id="user-content-r0s244" href="#r0s244">packages/jest-config/src/__tests__/getMaxWorkers.test.ts</a>
+```
+getMaxWorkers
+  :white_check_mark: Returns 1 when runInBand
+  :white_check_mark: Returns 1 when the OS CPUs are not available
+  :white_check_mark: Returns the `maxWorkers` when specified
+  :white_check_mark: Returns based on the number of cpus
+getMaxWorkers % based
+  :white_check_mark: 50% = 2 workers
+  :white_check_mark: < 0 workers should become 1
+  :white_check_mark: 0% shouldn't break
+```
+### :white_check_mark: <a id="user-content-r0s245" href="#r0s245">packages/jest-config/src/__tests__/normalize.test.js</a>
+```
+:white_check_mark: picks a name based on the rootDir
+:white_check_mark: keeps custom project name based on the projects rootDir
+:white_check_mark: keeps custom names based on the rootDir
+:white_check_mark: minimal config is stable across runs
+:white_check_mark: sets coverageReporters correctly when argv.json is set
+rootDir
+  :white_check_mark: throws if the options is missing a rootDir property
+automock
+  :white_check_mark: falsy automock is not overwritten
+collectCoverageOnlyFrom
+  :white_check_mark: normalizes all paths relative to rootDir
+  :white_check_mark: does not change absolute paths
+  :white_check_mark: substitutes <rootDir> tokens
+collectCoverageFrom
+  :white_check_mark: substitutes <rootDir> tokens
+findRelatedTests
+  :white_check_mark: it generates --coverageCoverageFrom patterns when needed
+roots
+  :white_check_mark: normalizes all paths relative to rootDir
+  :white_check_mark: does not change absolute paths
+  :white_check_mark: substitutes <rootDir> tokens
+transform
+  :white_check_mark: normalizes the path
+  :white_check_mark: pulls in config if it's passed as an array, and defaults to empty object
+haste
+  :white_check_mark: normalizes the path for hasteImplModulePath
+setupFilesAfterEnv
+  :white_check_mark: normalizes the path according to rootDir
+  :white_check_mark: does not change absolute paths
+  :white_check_mark: substitutes <rootDir> tokens
+setupTestFrameworkScriptFile
+  :white_check_mark: logs a deprecation warning when `setupTestFrameworkScriptFile` is used
+  :white_check_mark: logs an error when `setupTestFrameworkScriptFile` and `setupFilesAfterEnv` are used
+coveragePathIgnorePatterns
+  :white_check_mark: does not normalize paths relative to rootDir
+  :white_check_mark: does not normalize trailing slashes
+  :white_check_mark: substitutes <rootDir> tokens
+watchPathIgnorePatterns
+  :white_check_mark: does not normalize paths relative to rootDir
+  :white_check_mark: does not normalize trailing slashes
+  :white_check_mark: substitutes <rootDir> tokens
+testPathIgnorePatterns
+  :white_check_mark: does not normalize paths relative to rootDir
+  :white_check_mark: does not normalize trailing slashes
+  :white_check_mark: substitutes <rootDir> tokens
+modulePathIgnorePatterns
+  :white_check_mark: does not normalize paths relative to rootDir
+  :white_check_mark: does not normalize trailing slashes
+  :white_check_mark: substitutes <rootDir> tokens
+testRunner
+  :white_check_mark: defaults to Circus
+  :white_check_mark: resolves jasmine
+  :white_check_mark: is overwritten by argv
+coverageDirectory
+  :white_check_mark: defaults to <rootDir>/coverage
+testEnvironment
+  :white_check_mark: resolves to an environment and prefers jest-environment-`name`
+  :white_check_mark: throws on invalid environment names
+  :white_check_mark: works with rootDir
+babel-jest
+  :white_check_mark: correctly identifies and uses babel-jest
+  :white_check_mark: uses babel-jest if babel-jest is explicitly specified in a custom transform options
+Upgrade help
+  :white_check_mark: logs a warning when `scriptPreprocessor` and/or `preprocessorIgnorePatterns` are used
+testRegex
+  :white_check_mark: testRegex empty string is mapped to empty array
+  :white_check_mark: testRegex string is mapped to an array
+  :white_check_mark: testRegex array is preserved
+testMatch
+  :white_check_mark: testMatch default not applied if testRegex is set
+  :white_check_mark: testRegex default not applied if testMatch is set
+  :white_check_mark: throws if testRegex and testMatch are both specified
+  :white_check_mark: normalizes testMatch
+moduleDirectories
+  :white_check_mark: defaults to node_modules
+  :white_check_mark: normalizes moduleDirectories
+preset
+  :white_check_mark: throws when preset not found
+  :white_check_mark: throws when module was found but no "jest-preset.js" or "jest-preset.json" files
+  :white_check_mark: throws when a dependency is missing in the preset
+  :white_check_mark: throws when preset is invalid
+  :white_check_mark: throws when preset evaluation throws type error
+  :white_check_mark: works with "react-native"
+  :white_check_mark: searches for .json and .js preset files
+  :white_check_mark: merges with options
+  :white_check_mark: merges with options and moduleNameMapper preset is overridden by options
+  :white_check_mark: merges with options and transform preset is overridden by options
+  :white_check_mark: extracts setupFilesAfterEnv from preset
+preset with globals
+  :white_check_mark: should merge the globals preset correctly
+preset without setupFiles
+  :white_check_mark: should normalize setupFiles correctly
+preset without setupFilesAfterEnv
+  :white_check_mark: should normalize setupFilesAfterEnv correctly
+runner
+  :white_check_mark: defaults to `jest-runner`
+  :white_check_mark: resolves to runners that do not have the prefix
+  :white_check_mark: resolves to runners and prefers jest-runner-`name`
+  :white_check_mark: throw error when a runner is not found
+watchPlugins
+  :white_check_mark: defaults to undefined
+  :white_check_mark: resolves to watch plugins and prefers jest-watch-`name`
+  :white_check_mark: resolves watch plugins that do not have the prefix
+  :white_check_mark: normalizes multiple watchPlugins
+  :white_check_mark: throw error when a watch plugin is not found
+testPathPattern
+  :white_check_mark: defaults to empty
+  :white_check_mark: joins multiple --testPathPatterns and <regexForTestFiles>
+  :white_check_mark: gives precedence to --all
+testPathPattern --testPathPattern
+  :white_check_mark: uses --testPathPattern if set
+  :white_check_mark: ignores invalid regular expressions and logs a warning
+  :white_check_mark: joins multiple --testPathPattern if set
+testPathPattern --testPathPattern posix
+  :white_check_mark: should not escape the pattern
+testPathPattern --testPathPattern win32
+  :white_check_mark: preserves any use of "\"
+  :white_check_mark: replaces POSIX path separators
+  :white_check_mark: replaces POSIX paths in multiple args
+  :white_check_mark: coerces all patterns to strings
+testPathPattern <regexForTestFiles>
+  :white_check_mark: uses <regexForTestFiles> if set
+  :white_check_mark: ignores invalid regular expressions and logs a warning
+  :white_check_mark: joins multiple <regexForTestFiles> if set
+testPathPattern <regexForTestFiles> posix
+  :white_check_mark: should not escape the pattern
+testPathPattern <regexForTestFiles> win32
+  :white_check_mark: preserves any use of "\"
+  :white_check_mark: replaces POSIX path separators
+  :white_check_mark: replaces POSIX paths in multiple args
+  :white_check_mark: coerces all patterns to strings
+moduleFileExtensions
+  :white_check_mark: defaults to something useful
+  :white_check_mark: throws if missing `js` but using jest-runner
+  :white_check_mark: does not throw if missing `js` with a custom runner
+cwd
+  :white_check_mark: is set to process.cwd
+  :white_check_mark: is not lost if the config has its own cwd property
+Defaults
+  :white_check_mark: should be accepted by normalize
+displayName
+  :white_check_mark: should throw an error when displayName is is an empty object
+  :white_check_mark: should throw an error when displayName is missing color
+  :white_check_mark: should throw an error when displayName is missing name
+  :white_check_mark: should throw an error when displayName is using invalid values
+  :white_check_mark: generates a default color for the runner undefined
+  :white_check_mark: generates a default color for the runner jest-runner
+  :white_check_mark: generates a default color for the runner jest-runner-eslint
+  :white_check_mark: generates a default color for the runner jest-runner-tslint
+  :white_check_mark: generates a default color for the runner jest-runner-tsc
+testTimeout
+  :white_check_mark: should return timeout value if defined
+  :white_check_mark: should throw an error if timeout is a negative number
+extensionsToTreatAsEsm
+  :white_check_mark: should pass valid config through
+  :white_check_mark: should enforce leading dots
+  :white_check_mark: throws on .js
+  :white_check_mark: throws on .mjs
+  :white_check_mark: throws on .cjs
+```
+### :white_check_mark: <a id="user-content-r0s246" href="#r0s246">packages/jest-config/src/__tests__/readConfig.test.ts</a>
+```
+:white_check_mark: readConfig() throws when an object is passed without a file path
+```
+### :white_check_mark: <a id="user-content-r0s247" href="#r0s247">packages/jest-config/src/__tests__/readConfigs.test.ts</a>
+```
+:white_check_mark: readConfigs() throws when called without project paths
+:white_check_mark: readConfigs() loads async config file
+:white_check_mark: readConfigs() reject if async was rejected
+```
+### :white_check_mark: <a id="user-content-r0s248" href="#r0s248">packages/jest-config/src/__tests__/resolveConfigPath.test.ts</a>
+```
+Resolve config path .js
+  :white_check_mark: file path with ".js"
+  :white_check_mark: directory path with ".js"
+Resolve config path .ts
+  :white_check_mark: file path with ".ts"
+  :white_check_mark: directory path with ".ts"
+Resolve config path .mjs
+  :white_check_mark: file path with ".mjs"
+  :white_check_mark: directory path with ".mjs"
+Resolve config path .cjs
+  :white_check_mark: file path with ".cjs"
+  :white_check_mark: directory path with ".cjs"
+Resolve config path .json
+  :white_check_mark: file path with ".json"
+  :white_check_mark: directory path with ".json"
+```
+### :white_check_mark: <a id="user-content-r0s249" href="#r0s249">packages/jest-config/src/__tests__/setFromArgv.test.ts</a>
+```
+:white_check_mark: maps special values to valid options
+:white_check_mark: maps regular values to themselves
+:white_check_mark: works with string objects
+:white_check_mark: explicit flags override those from --config
+```
+### :white_check_mark: <a id="user-content-r0s250" href="#r0s250">packages/jest-config/src/__tests__/validatePattern.test.ts</a>
+```
+validate pattern function
+  :white_check_mark: without passed args returns true
+  :white_check_mark: returns true for empty pattern
+  :white_check_mark: returns true for valid pattern
+  :white_check_mark: returns false for invalid pattern
+```
+### :white_check_mark: <a id="user-content-r0s251" href="#r0s251">packages/jest-console/src/__tests__/bufferedConsole.test.ts</a>
+```
+CustomConsole assert
+  :white_check_mark: do not log when the assertion is truthy
+  :white_check_mark: do not log when the assertion is truthy and there is a message
+  :white_check_mark: log the assertion error when the assertion is falsy
+  :white_check_mark: log the assertion error when the assertion is falsy with another message argument
+CustomConsole count
+  :white_check_mark: count using the default counter
+  :white_check_mark: count using the a labeled counter
+  :white_check_mark: countReset restarts default counter
+  :white_check_mark: countReset restarts custom counter
+CustomConsole group
+  :white_check_mark: group without label
+  :white_check_mark: group with label
+  :white_check_mark: groupEnd remove the indentation of the current group
+  :white_check_mark: groupEnd can not remove the indentation below the starting point
+CustomConsole time
+  :white_check_mark: should return the time between time() and timeEnd() on default timer
+  :white_check_mark: should return the time between time() and timeEnd() on custom timer
+CustomConsole dir
+  :white_check_mark: should print the deepest value
+CustomConsole timeLog
+  :white_check_mark: should return the time between time() and timeEnd() on default timer
+  :white_check_mark: should return the time between time() and timeEnd() on custom timer
+  :white_check_mark: default timer with data
+  :white_check_mark: custom timer with data
+CustomConsole console
+  :white_check_mark: should be able to initialize console instance
+```
+### :white_check_mark: <a id="user-content-r0s252" href="#r0s252">packages/jest-console/src/__tests__/CustomConsole.test.ts</a>
+```
+CustomConsole log
+  :white_check_mark: should print to stdout
+CustomConsole error
+  :white_check_mark: should print to stderr
+CustomConsole warn
+  :white_check_mark: should print to stderr
+CustomConsole assert
+  :white_check_mark: do not log when the assertion is truthy
+  :white_check_mark: do not log when the assertion is truthy and there is a message
+  :white_check_mark: log the assertion error when the assertion is falsy
+  :white_check_mark: log the assertion error when the assertion is falsy with another message argument
+CustomConsole count
+  :white_check_mark: count using the default counter
+  :white_check_mark: count using the a labeled counter
+  :white_check_mark: countReset restarts default counter
+  :white_check_mark: countReset restarts custom counter
+CustomConsole group
+  :white_check_mark: group without label
+  :white_check_mark: group with label
+  :white_check_mark: groupEnd remove the indentation of the current group
+  :white_check_mark: groupEnd can not remove the indentation below the starting point
+CustomConsole time
+  :white_check_mark: should return the time between time() and timeEnd() on default timer
+  :white_check_mark: should return the time between time() and timeEnd() on custom timer
+CustomConsole dir
+  :white_check_mark: should print the deepest value
+CustomConsole timeLog
+  :white_check_mark: should return the time between time() and timeEnd() on default timer
+  :white_check_mark: should return the time between time() and timeEnd() on custom timer
+  :white_check_mark: default timer with data
+  :white_check_mark: custom timer with data
+CustomConsole console
+  :white_check_mark: should be able to initialize console instance
+```
+### :white_check_mark: <a id="user-content-r0s253" href="#r0s253">packages/jest-console/src/__tests__/getConsoleOutput.test.ts</a>
+```
+getConsoleOutput
+  :white_check_mark: takes noStackTrace and pass it on for assert
+  :white_check_mark: takes noStackTrace and pass it on for count
+  :white_check_mark: takes noStackTrace and pass it on for debug
+  :white_check_mark: takes noStackTrace and pass it on for dir
+  :white_check_mark: takes noStackTrace and pass it on for dirxml
+  :white_check_mark: takes noStackTrace and pass it on for error
+  :white_check_mark: takes noStackTrace and pass it on for group
+  :white_check_mark: takes noStackTrace and pass it on for groupCollapsed
+  :white_check_mark: takes noStackTrace and pass it on for info
+  :white_check_mark: takes noStackTrace and pass it on for log
+  :white_check_mark: takes noStackTrace and pass it on for time
+  :white_check_mark: takes noStackTrace and pass it on for warn
+```
+### :white_check_mark: <a id="user-content-r0s254" href="#r0s254">packages/jest-core/src/__tests__/FailedTestsCache.test.js</a>
+```
+FailedTestsCache
+  :white_check_mark: should filter tests
+```
+### :white_check_mark: <a id="user-content-r0s255" href="#r0s255">packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js</a>
+```
+getNoTestsFoundMessage
+  :white_check_mark: returns correct message when monitoring only failures
+  :white_check_mark: returns correct message when monitoring only changed
+  :white_check_mark: returns correct message with verbose option
+  :white_check_mark: returns correct message without options
+  :white_check_mark: returns correct message with passWithNoTests
+```
+### :white_check_mark: <a id="user-content-r0s256" href="#r0s256">packages/jest-core/src/__tests__/globals.test.ts</a>
+```
+Common globals
+  :white_check_mark: check process
+```
+### :white_check_mark: <a id="user-content-r0s257" href="#r0s257">packages/jest-core/src/__tests__/runJest.test.js</a>
+```
+runJest
+  :white_check_mark: when watch is set then exit process
+  :white_check_mark: when watch is set then an error message is printed
+```
+### :white_check_mark: <a id="user-content-r0s258" href="#r0s258">packages/jest-core/src/__tests__/SearchSource.test.ts</a>
+```
+SearchSource isTestFilePath
+  :white_check_mark: supports ../ paths and unix separators via testRegex
+  :white_check_mark: supports unix separators
+  :white_check_mark: supports win32 separators
+SearchSource testPathsMatching
+  :white_check_mark: finds tests matching a pattern via testRegex
+  :white_check_mark: finds tests matching a pattern via testMatch
+  :white_check_mark: finds tests matching a JS regex pattern
+  :white_check_mark: finds tests matching a JS glob pattern
+  :white_check_mark: finds tests matching a JS with overriding glob patterns
+  :white_check_mark: finds tests with default file extensions using testRegex
+  :white_check_mark: finds tests with default file extensions using testMatch
+  :white_check_mark: finds tests with parentheses in their rootDir when using testMatch
+  :white_check_mark: finds tests with similar but custom file extensions
+  :white_check_mark: finds tests with totally custom foobar file extensions
+  :white_check_mark: finds tests with many kinds of file extensions
+  :white_check_mark: finds tests using a regex only
+  :white_check_mark: finds tests using a glob only
+SearchSource findRelatedTests
+  :white_check_mark: makes sure a file is related to itself
+  :white_check_mark: finds tests that depend directly on the path
+  :white_check_mark: excludes untested files from coverage
+SearchSource findRelatedTestsFromPattern
+  :white_check_mark: returns empty search result for empty input
+  :white_check_mark: returns empty search result for invalid input
+  :white_check_mark: returns empty search result if no related tests were found
+  :white_check_mark: finds tests for a single file
+  :white_check_mark: finds tests for multiple files
+  :white_check_mark: does not mistake roots folders with prefix names
+SearchSource findRelatedSourcesFromTestsInChangedFiles
+  :white_check_mark: return empty set if no SCM
+  :white_check_mark: return sources required by tests
+```
+### :white_check_mark: <a id="user-content-r0s259" href="#r0s259">packages/jest-core/src/__tests__/SnapshotInteractiveMode.test.js</a>
+```
+SnapshotInteractiveMode
+  :white_check_mark: is inactive at construction
+  :white_check_mark: call to run process the first file
+  :white_check_mark: call to abort
+  :white_check_mark: call to reset
+  :white_check_mark: press Q or ESC triggers an abort
+  :white_check_mark: press ENTER trigger a run
+  :white_check_mark: skip 1 test, then restart
+  :white_check_mark: skip 1 test, then quit
+  :white_check_mark: update 1 test, then finish and return
+  :white_check_mark: skip 2 tests, then finish and restart
+  :white_check_mark: update 2 tests, then finish and return
+  :white_check_mark: update 1 test, skip 1 test, then finish and restart
+  :white_check_mark: skip 1 test, update 1 test, then finish and restart
+```
+### :white_check_mark: <a id="user-content-r0s260" href="#r0s260">packages/jest-core/src/__tests__/TestScheduler.test.js</a>
+```
+:white_check_mark: config for reporters supports `default`
+:white_check_mark: .addReporter() .removeReporter()
+:white_check_mark: schedule tests run in parallel per default
+:white_check_mark: schedule tests run in serial if the runner flags them
+:white_check_mark: should bail after `n` failures
+:white_check_mark: should not bail if less than `n` failures
+:white_check_mark: should set runInBand to run in serial
+:white_check_mark: should set runInBand to not run in serial
+```
+### :white_check_mark: <a id="user-content-r0s261" href="#r0s261">packages/jest-core/src/__tests__/testSchedulerHelper.test.js</a>
+```
+:white_check_mark: shouldRunInBand() - should return true for runInBand mode
+:white_check_mark: shouldRunInBand() - should return true for runInBand mode
+:white_check_mark: shouldRunInBand() - should return false for runInBand mode
+:white_check_mark: shouldRunInBand() - should return false for runInBand mode
+:white_check_mark: shouldRunInBand() - should return false for runInBand mode
+:white_check_mark: shouldRunInBand() - should return true for runInBand mode
+:white_check_mark: shouldRunInBand() - should return false for runInBand mode
+:white_check_mark: shouldRunInBand() - should return true for runInBand mode
+:white_check_mark: shouldRunInBand() - should return true for runInBand mode
+:white_check_mark: shouldRunInBand() - should return false for runInBand mode
+:white_check_mark: shouldRunInBand() - should return false for runInBand mode
+:white_check_mark: shouldRunInBand() - should return true for runInBand mode
+```
+### :white_check_mark: <a id="user-content-r0s262" href="#r0s262">packages/jest-core/src/__tests__/watch.test.js</a>
+```
+Watch mode flows
+  :white_check_mark: Correctly passing test path pattern
+  :white_check_mark: Correctly passing test name pattern
+  :white_check_mark: Runs Jest once by default and shows usage
+  :white_check_mark: Runs Jest in a non-interactive environment not showing usage
+  :white_check_mark: resolves relative to the package root
+  :white_check_mark: shows prompts for WatchPlugins in alphabetical order
+  :white_check_mark: shows update snapshot prompt (without interactive)
+  :white_check_mark: shows update snapshot prompt (with interactive)
+  :white_check_mark: allows WatchPlugins to hook into JestHook
+  :white_check_mark: allows WatchPlugins to override eligible internal plugins
+  :white_check_mark: allows WatchPlugins to be configured
+  :white_check_mark: allows WatchPlugins to hook into file system changes
+  :white_check_mark: makes watch plugin initialization errors look nice
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: allows WatchPlugins to modify only white-listed global config keys
+  :white_check_mark: triggers enter on a WatchPlugin when its key is pressed
+  :white_check_mark: prevents Jest from handling keys when active and returns control when end is called
+  :white_check_mark: Pressing "o" runs test in "only changed files" mode
+  :white_check_mark: Pressing "a" runs test in "watch all" mode
+  :white_check_mark: Pressing "ENTER" reruns the tests
+  :white_check_mark: Pressing "t" reruns the tests in "test name pattern" mode
+  :white_check_mark: Pressing "p" reruns the tests in "filename pattern" mode
+  :white_check_mark: Can combine "p" and "t" filters
+  :white_check_mark: Pressing "u" reruns the tests in "update snapshot" mode
+  :white_check_mark: passWithNoTest should be set to true in watch mode
+  :white_check_mark: shows the correct usage for the f key in "only failed tests" mode
+Watch mode flows when dealing with potential watch plugin key conflicts
+  :white_check_mark: forbids WatchPlugins overriding reserved internal plugins
+  :white_check_mark: forbids WatchPlugins overriding reserved internal plugins
+  :white_check_mark: forbids WatchPlugins overriding reserved internal plugins
+  :white_check_mark: allows WatchPlugins to override non-reserved internal plugins
+  :white_check_mark: allows WatchPlugins to override non-reserved internal plugins
+  :white_check_mark: forbids third-party WatchPlugins overriding each other
+```
+### :white_check_mark: <a id="user-content-r0s263" href="#r0s263">packages/jest-core/src/__tests__/watchFileChanges.test.ts</a>
+```
+Watch mode flows with changed files
+  :white_check_mark: should correct require new files without legacy cache
+```
+### :white_check_mark: <a id="user-content-r0s264" href="#r0s264">packages/jest-core/src/__tests__/watchFilenamePatternMode.test.js</a>
+```
+Watch mode flows
+  :white_check_mark: Pressing "P" enters pattern mode
+  :white_check_mark: Pressing "c" clears the filters
+```
+### :white_check_mark: <a id="user-content-r0s265" href="#r0s265">packages/jest-core/src/__tests__/watchTestNamePatternMode.test.js</a>
+```
+Watch mode flows
+  :white_check_mark: Pressing "T" enters pattern mode
+```
+### :white_check_mark: <a id="user-content-r0s266" href="#r0s266">packages/jest-core/src/lib/__tests__/isValidPath.test.ts</a>
+```
+:white_check_mark: is valid when it is a file inside roots
+:white_check_mark: is not valid when it is a snapshot file
+:white_check_mark: is not valid when it is a file in the coverage dir
+```
+### :white_check_mark: <a id="user-content-r0s267" href="#r0s267">packages/jest-core/src/lib/__tests__/logDebugMessages.test.ts</a>
+```
+:white_check_mark: prints the jest version
+:white_check_mark: prints the test framework name
+:white_check_mark: prints the config object
+```
+### :white_check_mark: <a id="user-content-r0s268" href="#r0s268">packages/jest-create-cache-key-function/src/__tests__/index.test.ts</a>
+```
+:white_check_mark: creation of a cache key
+```
+### :white_check_mark: <a id="user-content-r0s269" href="#r0s269">packages/jest-diff/src/__tests__/diff.test.ts</a>
+```
+different types
+  :white_check_mark: '1' and 'a'
+  :white_check_mark: '[object Object]' and 'a'
+  :white_check_mark: '' and '2'
+  :white_check_mark: 'null' and 'undefined'
+  :white_check_mark: '() => {}' and '3'
+no visual difference
+  :white_check_mark: '"a"' and '"a"'
+  :white_check_mark: '{}' and '{}'
+  :white_check_mark: '[]' and '[]'
+  :white_check_mark: '[1,2]' and '[1,2]'
+  :white_check_mark: '11' and '11'
+  :white_check_mark: 'null' and 'null'
+  :white_check_mark: 'null' and 'null'
+  :white_check_mark: 'undefined' and 'undefined'
+  :white_check_mark: 'null' and 'null'
+  :white_check_mark: 'undefined' and 'undefined'
+  :white_check_mark: 'false' and 'false'
+  :white_check_mark: '{"a":1}' and '{"a":1}'
+  :white_check_mark: '{"a":{"b":5}}' and '{"a":{"b":5}}'
+  :white_check_mark: Map key order should be irrelevant
+  :white_check_mark: Set value order should be irrelevant
+:white_check_mark: oneline strings
+:white_check_mark: numbers
+:white_check_mark: -0 and 0
+:white_check_mark: booleans
+:white_check_mark: collapses big diffs to patch format
+falls back to not call toJSON if serialization has no differences
+  :white_check_mark: but then objects have differences
+  :white_check_mark: and then objects have no differences
+falls back to not call toJSON if it throws
+  :white_check_mark: and then objects have differences
+  :white_check_mark: and then objects have no differences
+multiline strings
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+objects
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+multiline string non-snapshot
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+multiline string snapshot
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+React elements
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+multiline string as value of object property (non-snapshot)
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+multiline string as value of object property (snapshot)
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+indentation in JavaScript structures from less to more
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+indentation in JavaScript structures from more to less
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+color of text
+  :white_check_mark: (expanded)
+  :white_check_mark: (unexpanded)
+indentation in React elements (non-snapshot) from less to more
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+indentation in React elements (non-snapshot) from more to less
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+indentation in React elements (snapshot) from less to more
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+indentation in React elements (snapshot) from more to less
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+outer React element (non-snapshot) from less to more
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+outer React element (non-snapshot) from more to less
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+trailing newline in multiline string not enclosed in quotes from less to more
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+trailing newline in multiline string not enclosed in quotes from more to less
+  :white_check_mark: (unexpanded)
+  :white_check_mark: (expanded)
+context
+  :white_check_mark: number of lines: -1 (5 default)
+  :white_check_mark: number of lines: 0
+  :white_check_mark: number of lines: 1
+  :white_check_mark: number of lines: 2
+  :white_check_mark: number of lines: 3.1 (5 default)
+  :white_check_mark: number of lines: undefined (5 default)
+diffLinesUnified edge cases
+  :white_check_mark: a empty string b empty string
+  :white_check_mark: a empty string b one line
+  :white_check_mark: a multiple lines b empty string
+  :white_check_mark: a one line b multiple lines
+diffLinesUnified2 edge cases
+  :white_check_mark: a empty string b empty string
+  :white_check_mark: a empty string b one line
+  :white_check_mark: a multiple lines b empty string
+  :white_check_mark: a one line b multiple lines
+diffLinesUnified2 edge cases lengths not equal
+  :white_check_mark: a
+  :white_check_mark: b
+diffStringsUnified edge cases
+  :white_check_mark: empty both a and b
+  :white_check_mark: empty only a
+  :white_check_mark: empty only b
+  :white_check_mark: equal both non-empty
+  :white_check_mark: multiline has no common after clean up chaff
+  :white_check_mark: one-line has no common after clean up chaff
+options 7980
+  :white_check_mark: diff
+  :white_check_mark: diffStringsUnified
+options change indicators
+  :white_check_mark: diff
+options change color
+  :white_check_mark: diffStringsUnified
+  :white_check_mark: no diff
+options common
+  :white_check_mark: diff
+  :white_check_mark: no diff
+options includeChangeCounts false
+  :white_check_mark: diffLinesUnified
+  :white_check_mark: diffStringsUnified
+options includeChangeCounts true padding
+  :white_check_mark: diffLinesUnified a has 2 digits
+  :white_check_mark: diffLinesUnified b has 2 digits
+  :white_check_mark: diffStringsUnified
+options omitAnnotationLines true
+  :white_check_mark: diff
+  :white_check_mark: diffStringsUnified and includeChangeCounts true
+  :white_check_mark: diffStringsUnified empty strings
+options trailingSpaceFormatter
+  :white_check_mark: diffDefault default no color
+  :white_check_mark: diffDefault middle dot
+  :white_check_mark: diffDefault yellowish common
+options emptyFirstOrLastLinePlaceholder default empty string
+  :white_check_mark: diffDefault
+  :white_check_mark: diffStringsUnified
+```
+### :white_check_mark: <a id="user-content-r0s270" href="#r0s270">packages/jest-diff/src/__tests__/diffStringsRaw.test.ts</a>
+```
+diffStringsRaw
+  :white_check_mark: one-line with cleanup
+  :white_check_mark: one-line without cleanup
+```
+### :white_check_mark: <a id="user-content-r0s271" href="#r0s271">packages/jest-diff/src/__tests__/getAlignedDiffs.test.ts</a>
+```
+getAlignedDiffs lines
+  :white_check_mark: change preceding and following common
+  :white_check_mark: common preceding and following change
+  :white_check_mark: common at end when both current change lines are empty
+  :white_check_mark: common between delete and insert
+  :white_check_mark: common between insert and delete
+getAlignedDiffs newline
+  :white_check_mark: delete only
+  :white_check_mark: insert only
+  :white_check_mark: delete with adjacent change
+  :white_check_mark: insert with adjacent changes
+  :white_check_mark: change from space
+  :white_check_mark: change to space
+getAlignedDiffs substrings first
+  :white_check_mark: common when both current change lines are empty
+  :white_check_mark: common when either current change line is non-empty
+  :white_check_mark: delete completes the current line
+  :white_check_mark: insert completes the current line
+getAlignedDiffs substrings middle
+  :white_check_mark: is empty in delete between common
+  :white_check_mark: is empty in insert at start
+  :white_check_mark: is non-empty in delete at end
+  :white_check_mark: is non-empty in insert between common
+getAlignedDiffs substrings last
+  :white_check_mark: is empty in delete at end
+  :white_check_mark: is empty in insert at end
+  :white_check_mark: is non-empty in common not at end
+getAlignedDiffs strings
+  :white_check_mark: change at start and delete or insert at end
+  :white_check_mark: delete or insert at start and change at end
+```
+### :white_check_mark: <a id="user-content-r0s272" href="#r0s272">packages/jest-diff/src/__tests__/joinAlignedDiffs.test.ts</a>
+```
+joinAlignedDiffsExpand
+  :white_check_mark: first line is empty common
+joinAlignedDiffsNoExpand
+  :white_check_mark: patch 0 with context 1 and change at start and end
+  :white_check_mark: patch 0 with context 5 and first line is empty common
+  :white_check_mark: patch 1 with context 4 and last line is empty common
+  :white_check_mark: patch 2 with context 3
+  :white_check_mark: patch 3 with context 2 and omit excess common at start
+```
+### :white_check_mark: <a id="user-content-r0s273" href="#r0s273">packages/jest-docblock/src/__tests__/index.test.ts</a>
+```
+docblock
+  :white_check_mark: extracts valid docblock with line comment
+  :white_check_mark: extracts valid docblock
+  :white_check_mark: extracts valid docblock with more comments
+  :white_check_mark: extracts from invalid docblock
+  :white_check_mark: returns extract and parsedocblock
+  :white_check_mark: parses directives out of a docblock
+  :white_check_mark: parses multiple of the same directives out of a docblock
+  :white_check_mark: parses >=3 of the same directives out of a docblock
+  :white_check_mark: parses directives out of a docblock with comments
+  :white_check_mark: parses directives out of a docblock with line comments
+  :white_check_mark: parses multiline directives
+  :white_check_mark: parses multiline directives even if there are linecomments within the docblock
+  :white_check_mark: supports slashes in @team directive
+  :white_check_mark: extracts comments from docblock
+  :white_check_mark: extracts multiline comments from docblock
+  :white_check_mark: preserves leading whitespace in multiline comments from docblock
+  :white_check_mark: removes leading newlines in multiline comments from docblock
+  :white_check_mark: extracts comments from beginning and end of docblock
+  :white_check_mark: preserve urls within a pragma's values
+  :white_check_mark: strip linecomments from pragmas but preserve for comments
+  :white_check_mark: extracts docblock comments as CRLF when docblock contains CRLF
+  :white_check_mark: extracts docblock comments as LF when docblock contains LF
+  :white_check_mark: strips the docblock out of a file that contains a top docblock
+  :white_check_mark: returns a file unchanged if there is no top docblock to strip
+  :white_check_mark: prints docblocks with no pragmas as empty string
+  :white_check_mark: prints docblocks with one pragma on one line
+  :white_check_mark: prints docblocks with multiple pragmas on multiple lines
+  :white_check_mark: prints docblocks with multiple of the same pragma
+  :white_check_mark: prints docblocks with pragmas
+  :white_check_mark: prints docblocks with comments
+  :white_check_mark: prints docblocks with comments and no keys
+  :white_check_mark: prints docblocks with multiline comments
+  :white_check_mark: prints docblocks that are parseable
+  :white_check_mark: can augment existing docblocks with comments
+  :white_check_mark: prints docblocks using CRLF if comments contains CRLF
+  :white_check_mark: prints docblocks using LF if comments contains LF
+```
+### :white_check_mark: <a id="user-content-r0s274" href="#r0s274">packages/jest-each/src/__tests__/array.test.ts</a>
+```
+jest-each .test
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each .test.concurrent
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each .test.concurrent.only
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each .test.concurrent.skip
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using sprintf format
+  :white_check_mark: calls global with title with placeholder values correctly interpolated
+jest-each .test.only
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each .it
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each .fit
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each .it.only
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each .describe
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each .fdescribe
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each .describe.only
+  :white_check_mark: throws an error when not called with an array
+  :white_check_mark: throws an error when called with an empty array
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using printf format
+  :white_check_mark: does not call global test with title containing more param values than sprintf placeholders
+  :white_check_mark: calls global test title with %p placeholder injected at the correct positions
+  :white_check_mark: does not calls global test title with %p placeholder when no data is supplied at given position
+  :white_check_mark: calls global with cb function containing all parameters of each test case when given 1d array
+  :white_check_mark: calls global with cb function containing all parameters of each test case 2d array
+  :white_check_mark: calls global with given timeout
+jest-each done callback
+  :white_check_mark: calls [ 'test' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'test', 'only' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'test', 'concurrent' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'test', 'concurrent', 'only' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'it' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'fit' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'it', 'only' ] with done when cb function has more args than params of given test row
+  :white_check_mark: does not call [ 'describe' ] with done when test function has more args than params of given test row
+  :white_check_mark: does not call [ 'fdescribe' ] with done when test function has more args than params of given test row
+  :white_check_mark: does not call [ 'describe', 'only' ] with done when test function has more args than params of given test row
+jest-each .xtest
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using sprintf format
+  :white_check_mark: calls global with title with placeholder values correctly interpolated
+jest-each .test.skip
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using sprintf format
+  :white_check_mark: calls global with title with placeholder values correctly interpolated
+jest-each .xit
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using sprintf format
+  :white_check_mark: calls global with title with placeholder values correctly interpolated
+jest-each .it.skip
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using sprintf format
+  :white_check_mark: calls global with title with placeholder values correctly interpolated
+jest-each .xdescribe
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using sprintf format
+  :white_check_mark: calls global with title with placeholder values correctly interpolated
+jest-each .describe.skip
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using sprintf format
+  :white_check_mark: calls global with title with placeholder values correctly interpolated
+```
+### :white_check_mark: <a id="user-content-r0s275" href="#r0s275">packages/jest-each/src/__tests__/index.test.ts</a>
+```
+array .add
+  :white_check_mark: returns the result of adding 0 to 0
+  :white_check_mark: returns the result of adding 0 to 1
+  :white_check_mark: returns the result of adding 1 to 1
+concurrent .add
+  :white_check_mark: returns the result of adding 0 to 0
+  :white_check_mark: returns the result of adding 0 to 1
+  :white_check_mark: returns the result of adding 1 to 1
+template .add
+  :white_check_mark: returns 0 when given 0 and 0
+  :white_check_mark: returns 1 when given 0 and 1
+  :white_check_mark: returns 2 when given 1 and 1
+:white_check_mark: throws an error when not called with the right number of arguments
+```
+### :white_check_mark: <a id="user-content-r0s276" href="#r0s276">packages/jest-each/src/__tests__/template.test.ts</a>
+```
+jest-each .test
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+jest-each .test.concurrent
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+jest-each .test.concurrent.only
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+jest-each .test.concurrent.skip
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+jest-each .test.only
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+jest-each .it
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+jest-each .fit
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+jest-each .it.only
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+jest-each .describe
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+jest-each .fdescribe
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+jest-each .describe.only
+  :white_check_mark: throws error when there are additional words in first column heading
+  :white_check_mark: throws error when there are additional words in second column heading
+  :white_check_mark: throws error when there are additional words in last column heading
+  :white_check_mark: does not throw error when there is additional words in template after heading row
+  :white_check_mark: does not throw error when there is only one column
+  :white_check_mark: does not throw error when there is only one column with additional words in template after heading
+  :white_check_mark: throws error when there are no arguments for given headings
+  :white_check_mark: throws error when there are fewer arguments than headings when given one row
+  :white_check_mark: throws error when there are fewer arguments than headings over multiple rows
+  :white_check_mark: throws an error when called with an empty string
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+  :white_check_mark: calls global with title containing $key in multiple positions
+  :white_check_mark: calls global with title containing $key.path
+  :white_check_mark: calls global with title containing last seen object when $key.path is invalid
+  :white_check_mark: calls global with cb function with object built from table headings and values
+  :white_check_mark: calls global with given timeout
+  :white_check_mark: formats primitive values using .toString()
+jest-each done callback
+  :white_check_mark: calls [ 'test' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'test', 'only' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'test', 'concurrent', 'only' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'it' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'fit' ] with done when cb function has more args than params of given test row
+  :white_check_mark: calls [ 'it', 'only' ] with done when cb function has more args than params of given test row
+  :white_check_mark: does not call [ 'describe' ] with done when test function has more args than params of given test row
+  :white_check_mark: does not call [ 'fdescribe' ] with done when test function has more args than params of given test row
+  :white_check_mark: does not call [ 'describe', 'only' ] with done when test function has more args than params of given test row
+jest-each .xtest
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+jest-each .test.skip
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+jest-each .xit
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+jest-each .it.skip
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+jest-each .xdescribe
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+jest-each .describe.skip
+  :white_check_mark: calls global with given title
+  :white_check_mark: calls global with given title when multiple tests cases exist
+  :white_check_mark: calls global with title containing param values when using $variable format
+```
+### :white_check_mark: <a id="user-content-r0s277" href="#r0s277">packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts</a>
+```
+JSDomEnvironment
+  :white_check_mark: should configure setTimeout/setInterval to use the browser api
+  :white_check_mark: has modern fake timers implementation
+```
+### :white_check_mark: <a id="user-content-r0s278" href="#r0s278">packages/jest-environment-node/src/__tests__/node_environment.test.ts</a>
+```
+NodeEnvironment
+  :white_check_mark: uses a copy of the process object
+  :white_check_mark: exposes process.on
+  :white_check_mark: exposes global.global
+  :white_check_mark: should configure setTimeout/setInterval to use the node api
+  :white_check_mark: has modern fake timers implementation
+  :white_check_mark: TextEncoder references the same global Uint8Array constructor
+```
+### :white_check_mark: <a id="user-content-r0s279" href="#r0s279">packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts</a>
+```
+FakeTimers construction
+  :white_check_mark: installs setTimeout mock
+  :white_check_mark: accepts to promisify setTimeout mock
+  :white_check_mark: installs clearTimeout mock
+  :white_check_mark: installs setInterval mock
+  :white_check_mark: installs clearInterval mock
+  :white_check_mark: mocks process.nextTick if it exists on global
+  :white_check_mark: mocks setImmediate if it exists on global
+  :white_check_mark: mocks clearImmediate if setImmediate is on global
+FakeTimers runAllTicks
+  :white_check_mark: runs all ticks, in order
+  :white_check_mark: does nothing when no ticks have been scheduled
+  :white_check_mark: only runs a scheduled callback once
+  :white_check_mark: cancels a callback even from native nextTick
+  :white_check_mark: cancels a callback even from native setImmediate
+  :white_check_mark: doesnt run a tick callback if native nextTick already did
+  :white_check_mark: doesnt run immediate if native setImmediate already did
+  :white_check_mark: native doesnt run immediate if fake already did
+  :white_check_mark: throws before allowing infinite recursion
+FakeTimers runAllTimers
+  :white_check_mark: runs all timers in order
+  :white_check_mark: warns when trying to advance timers while real timers are used
+  :white_check_mark: does nothing when no timers have been scheduled
+  :white_check_mark: only runs a setTimeout callback once (ever)
+  :white_check_mark: runs callbacks with arguments after the interval
+  :white_check_mark: doesnt pass the callback to native setTimeout
+  :white_check_mark: throws before allowing infinite recursion
+  :white_check_mark: also clears ticks
+FakeTimers advanceTimersByTime
+  :white_check_mark: runs timers in order
+  :white_check_mark: does nothing when no timers have been scheduled
+  :white_check_mark: throws before allowing infinite recursion
+FakeTimers advanceTimersToNextTimer
+  :white_check_mark: runs timers in order
+  :white_check_mark: run correct amount of steps
+  :white_check_mark: setTimeout inside setTimeout
+  :white_check_mark: does nothing when no timers have been scheduled
+FakeTimers reset
+  :white_check_mark: resets all pending setTimeouts
+  :white_check_mark: resets all pending setIntervals
+  :white_check_mark: resets all pending ticks callbacks & immediates
+  :white_check_mark: resets current advanceTimersByTime time cursor
+FakeTimers runOnlyPendingTimers
+  :white_check_mark: runs all timers in order
+  :white_check_mark: does not run timers that were cleared in another timer
+FakeTimers runWithRealTimers
+  :white_check_mark: executes callback with native timers
+  :white_check_mark: resets mock timers after executing callback
+  :white_check_mark: resets mock timer functions even if callback throws
+FakeTimers useRealTimers
+  :white_check_mark: resets native timer APIs
+  :white_check_mark: resets native process.nextTick when present
+  :white_check_mark: resets native setImmediate when present
+FakeTimers useFakeTimers
+  :white_check_mark: resets mock timer APIs
+  :white_check_mark: resets mock process.nextTick when present
+  :white_check_mark: resets mock setImmediate when present
+FakeTimers getTimerCount
+  :white_check_mark: returns the correct count
+  :white_check_mark: includes immediates and ticks
+  :white_check_mark: not includes cancelled immediates
+```
+### :white_check_mark: <a id="user-content-r0s280" href="#r0s280">packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts</a>
+```
+FakeTimers construction
+  :white_check_mark: installs setTimeout mock
+  :white_check_mark: installs clearTimeout mock
+  :white_check_mark: installs setInterval mock
+  :white_check_mark: installs clearInterval mock
+  :white_check_mark: mocks process.nextTick if it exists on global
+  :white_check_mark: mocks setImmediate if it exists on global
+  :white_check_mark: mocks clearImmediate if setImmediate is on global
+FakeTimers runAllTicks
+  :white_check_mark: runs all ticks, in order
+  :white_check_mark: does nothing when no ticks have been scheduled
+  :white_check_mark: only runs a scheduled callback once
+  :white_check_mark: throws before allowing infinite recursion
+FakeTimers runAllTimers
+  :white_check_mark: runs all timers in order
+  :white_check_mark: warns when trying to advance timers while real timers are used
+  :white_check_mark: does nothing when no timers have been scheduled
+  :white_check_mark: only runs a setTimeout callback once (ever)
+  :white_check_mark: runs callbacks with arguments after the interval
+  :white_check_mark: doesn't pass the callback to native setTimeout
+  :white_check_mark: throws before allowing infinite recursion
+  :white_check_mark: also clears ticks
+FakeTimers advanceTimersByTime
+  :white_check_mark: runs timers in order
+  :white_check_mark: does nothing when no timers have been scheduled
+FakeTimers advanceTimersToNextTimer
+  :white_check_mark: runs timers in order
+  :white_check_mark: run correct amount of steps
+  :white_check_mark: setTimeout inside setTimeout
+  :white_check_mark: does nothing when no timers have been scheduled
+FakeTimers reset
+  :white_check_mark: resets all pending setTimeouts
+  :white_check_mark: resets all pending setIntervals
+  :white_check_mark: resets all pending ticks callbacks
+  :white_check_mark: resets current advanceTimersByTime time cursor
+FakeTimers runOnlyPendingTimers
+  :white_check_mark: runs all timers in order
+  :white_check_mark: does not run timers that were cleared in another timer
+FakeTimers useRealTimers
+  :white_check_mark: resets native timer APIs
+  :white_check_mark: resets native process.nextTick when present
+  :white_check_mark: resets native setImmediate when present
+FakeTimers useFakeTimers
+  :white_check_mark: resets mock timer APIs
+  :white_check_mark: resets mock process.nextTick when present
+  :white_check_mark: resets mock setImmediate when present
+FakeTimers getTimerCount
+  :white_check_mark: returns the correct count
+  :white_check_mark: includes immediates and ticks
+  :white_check_mark: not includes cancelled immediates
+```
+### :white_check_mark: <a id="user-content-r0s281" href="#r0s281">packages/jest-get-type/src/__tests__/getType.test.ts</a>
+```
+.getType()
+  :white_check_mark: null
+  :white_check_mark: undefined
+  :white_check_mark: object
+  :white_check_mark: array
+  :white_check_mark: number
+  :white_check_mark: string
+  :white_check_mark: function
+  :white_check_mark: boolean
+  :white_check_mark: symbol
+  :white_check_mark: regexp
+  :white_check_mark: map
+  :white_check_mark: set
+  :white_check_mark: date
+  :white_check_mark: bigint
+```
+### :white_check_mark: <a id="user-content-r0s282" href="#r0s282">packages/jest-get-type/src/__tests__/isPrimitive.test.ts</a>
+```
+.isPrimitive()
+  :white_check_mark: returns true when given primitive value of: null
+  :white_check_mark: returns true when given primitive value of: undefined
+  :white_check_mark: returns true when given primitive value of: 100
+  :white_check_mark: returns true when given primitive value of: hello world
+  :white_check_mark: returns true when given primitive value of: true
+  :white_check_mark: returns true when given primitive value of: Symbol(a)
+  :white_check_mark: returns true when given primitive value of: 0
+  :white_check_mark: returns true when given primitive value of: NaN
+  :white_check_mark: returns true when given primitive value of: Infinity
+  :white_check_mark: returns true when given primitive value of: 1n
+  :white_check_mark: returns false when given non primitive value of: {}
+  :white_check_mark: returns false when given non primitive value of: []
+  :white_check_mark: returns false when given non primitive value of: undefined
+  :white_check_mark: returns false when given non primitive value of: {}
+  :white_check_mark: returns false when given non primitive value of: {}
+  :white_check_mark: returns false when given non primitive value of: {}
+  :white_check_mark: returns false when given non primitive value of: "2021-01-24T19:22:19.272Z"
+  :white_check_mark: returns false when given non primitive value of: {}
+```
+### :white_check_mark: <a id="user-content-r0s283" href="#r0s283">packages/jest-globals/src/__tests__/index.ts</a>
+```
+:white_check_mark: throw when directly imported
+```
+### :white_check_mark: <a id="user-content-r0s284" href="#r0s284">packages/jest-haste-map/src/__tests__/get_mock_name.test.js</a>
+```
+getMockName
+  :white_check_mark: extracts mock name from file path
+```
+### :white_check_mark: <a id="user-content-r0s285" href="#r0s285">packages/jest-haste-map/src/__tests__/includes_dotfiles.test.ts</a>
+```
+:white_check_mark: watchman crawler and node crawler both include dotfiles
+```
+### :white_check_mark: <a id="user-content-r0s286" href="#r0s286">packages/jest-haste-map/src/__tests__/index.test.js</a>
+```
+HasteMap
+  :white_check_mark: exports constants
+  :white_check_mark: creates valid cache file paths
+  :white_check_mark: creates different cache file paths for different roots
+  :white_check_mark: creates different cache file paths for different dependency extractor cache keys
+  :white_check_mark: creates different cache file paths for different hasteImplModulePath cache keys
+  :white_check_mark: creates different cache file paths for different projects
+  :white_check_mark: matches files against a pattern
+  :white_check_mark: ignores files given a pattern
+  :white_check_mark: ignores vcs directories without ignore pattern
+  :white_check_mark: ignores vcs directories with ignore pattern regex
+  :white_check_mark: warn on ignore pattern except for regex
+  :white_check_mark: builds a haste map on a fresh cache
+  :white_check_mark: does not crawl native files even if requested to do so
+  :white_check_mark: retains all files if `retainAllFiles` is specified
+  :white_check_mark: warns on duplicate mock files
+  :white_check_mark: warns on duplicate module ids
+  :white_check_mark: warns on duplicate module ids only once
+  :white_check_mark: throws on duplicate module ids if "throwOnModuleCollision" is set to true
+  :white_check_mark: splits up modules by platform
+  :white_check_mark: does not access the file system on a warm cache with no changes
+  :white_check_mark: only does minimal file system access when files change
+  :white_check_mark: correctly handles file deletions
+  :white_check_mark: correctly handles platform-specific file additions
+  :white_check_mark: correctly handles platform-specific file deletions
+  :white_check_mark: correctly handles platform-specific file renames
+  :white_check_mark: discards the cache when configuration changes
+  :white_check_mark: ignores files that do not exist
+  :white_check_mark: distributes work across workers
+  :white_check_mark: tries to crawl using node as a fallback
+  :white_check_mark: tries to crawl using node as a fallback when promise fails once
+  :white_check_mark: stops crawling when both crawlers fail
+HasteMap builds a haste map on a fresh cache with SHA-1s
+  :white_check_mark: uses watchman: false
+  :white_check_mark: uses watchman: true
+HasteMap duplicate modules
+  :white_check_mark: recovers when a duplicate file is deleted
+  :white_check_mark: recovers with the correct type when a duplicate file is deleted
+  :white_check_mark: recovers when a duplicate module is renamed
+HasteMap file system changes processing
+  :white_check_mark: provides a new set of hasteHS and moduleMap
+  :white_check_mark: handles several change events at once
+  :white_check_mark: does not emit duplicate change events
+  :white_check_mark: emits a change even if a file in node_modules has changed
+  :white_check_mark: correctly tracks changes to both platform-specific versions of a single module name
+HasteMap file system changes processing recovery from duplicate module IDs
+  :white_check_mark: recovers when the oldest version of the duplicates is fixed
+  :white_check_mark: recovers when the most recent duplicate is fixed
+  :white_check_mark: ignore directories
+```
+### :white_check_mark: <a id="user-content-r0s287" href="#r0s287">packages/jest-haste-map/src/__tests__/worker.test.js</a>
+```
+worker
+  :white_check_mark: parses JavaScript files and extracts module information
+  :white_check_mark: accepts a custom dependency extractor
+  :white_check_mark: delegates to hasteImplModulePath for getting the id
+  :white_check_mark: parses package.json files as haste packages
+  :white_check_mark: returns an error when a file cannot be accessed
+  :white_check_mark: simply computes SHA-1s when requested (works well with binary data)
+  :white_check_mark: avoids computing dependencies if not requested and Haste does not need it
+```
+### :white_check_mark: <a id="user-content-r0s288" href="#r0s288">packages/jest-haste-map/src/crawlers/__tests__/node.test.js</a>
+```
+node crawler
+  :white_check_mark: crawls for files based on patterns
+  :white_check_mark: updates only changed files
+  :white_check_mark: returns removed files
+  :white_check_mark: uses node fs APIs with incompatible find binary
+  :white_check_mark: uses node fs APIs without find binary
+  :white_check_mark: uses node fs APIs if "forceNodeFilesystemAPI" is set to true, regardless of platform
+  :white_check_mark: completes with empty roots
+  :white_check_mark: completes with fs.readdir throwing an error
+node crawler readdir withFileTypes support
+  :white_check_mark: calls lstat for directories and symlinks if readdir withFileTypes is not supported
+  :white_check_mark: avoids calling lstat for directories and symlinks if readdir withFileTypes is supported
+```
+### :white_check_mark: <a id="user-content-r0s289" href="#r0s289">packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js</a>
+```
+watchman watch
+  :white_check_mark: returns a list of all files when there are no clocks
+  :white_check_mark: updates file map and removedFiles when the clock is given
+  :white_check_mark: resets the file map and tracks removedFiles when watchman is fresh
+  :white_check_mark: properly resets the file map when only one watcher is reset
+  :white_check_mark: does not add directory filters to query when watching a ROOT
+  :white_check_mark: SHA-1 requested and available
+  :white_check_mark: SHA-1 requested and NOT available
+  :white_check_mark: source control query
+```
+### :white_check_mark: <a id="user-content-r0s290" href="#r0s290">packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js</a>
+```
+dependencyExtractor
+  :white_check_mark: should not extract dependencies inside comments
+  :white_check_mark: should not extract dependencies inside comments (windows line endings)
+  :white_check_mark: should not extract dependencies inside comments (unicode line endings)
+  :white_check_mark: should extract dependencies from `import` statements
+  :white_check_mark: should extract dependencies from side-effect only `import` statements
+  :white_check_mark: should not extract dependencies from `import type/typeof` statements
+  :white_check_mark: should extract dependencies from `export` statements
+  :white_check_mark: should extract dependencies from `export-from` statements
+  :white_check_mark: should not extract dependencies from `export type/typeof` statements
+  :white_check_mark: should extract dependencies from dynamic `import` calls
+  :white_check_mark: should extract dependencies from `require` calls
+  :white_check_mark: should extract dependencies from `jest.requireActual` calls
+  :white_check_mark: should extract dependencies from `jest.requireMock` calls
+  :white_check_mark: should extract dependencies from `jest.genMockFromModule` calls
+  :white_check_mark: should extract dependencies from `jest.createMockFromModule` calls
+```
+### :white_check_mark: <a id="user-content-r0s291" href="#r0s291">packages/jest-haste-map/src/lib/__tests__/fast_path.test.js</a>
+```
+fastPath.relative
+  :white_check_mark: should get relative paths inside the root
+  :white_check_mark: should get relative paths outside the root
+  :white_check_mark: should get relative paths outside the root when start with same word
+fastPath.resolve
+  :white_check_mark: should get the absolute path for paths inside the root
+  :white_check_mark: should get the absolute path for paths outside the root
+```
+### :white_check_mark: <a id="user-content-r0s292" href="#r0s292">packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js</a>
+```
+getPlatformExtension
+  :white_check_mark: should get platform ext
+```
+### :white_check_mark: <a id="user-content-r0s293" href="#r0s293">packages/jest-haste-map/src/lib/__tests__/isRegExpSupported.test.js</a>
+```
+isRegExpSupported
+  :white_check_mark: should return true when passing valid regular expression
+  :white_check_mark: should return false when passing an invalid regular expression
+```
+### :white_check_mark: <a id="user-content-r0s294" href="#r0s294">packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js</a>
+```
+normalizePathSep
+  :white_check_mark: does nothing on posix
+  :white_check_mark: replace slashes on windows
+```
+### :white_check_mark: <a id="user-content-r0s295" href="#r0s295">packages/jest-jasmine2/src/__tests__/concurrent.test.ts</a>
+```
+concurrent
+  :white_check_mark: should add 1 to number
+  :white_check_mark: should add 1 to number
+  :white_check_mark: should add 1 to number
+```
+### :white_check_mark: <a id="user-content-r0s296" href="#r0s296">packages/jest-jasmine2/src/__tests__/expectationResultFactory.test.ts</a>
+```
+expectationResultFactory
+  :white_check_mark: returns the result if passed.
+  :white_check_mark: returns the result if failed.
+  :white_check_mark: returns the result if failed (with `message`).
+  :white_check_mark: returns the result if failed (with `error`).
+  :white_check_mark: returns the error name if the error message is empty
+  :white_check_mark: returns the result if failed (with `error` as a string).
+  :white_check_mark: returns the result if failed (with `error.stack` not as a string).
+```
+### :white_check_mark: <a id="user-content-r0s297" href="#r0s297">packages/jest-jasmine2/src/__tests__/hooksError.test.ts</a>
+```
+beforeEach hooks error throwing
+  :white_check_mark: beforeEach throws an error when "String" is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when 1 is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when [] is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when {} is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when Symbol(hello) is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when true is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when null is provided as a first argument to it
+  :white_check_mark: beforeEach throws an error when undefined is provided as a first argument to it
+beforeAll hooks error throwing
+  :white_check_mark: beforeAll throws an error when "String" is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when 1 is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when [] is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when {} is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when Symbol(hello) is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when true is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when null is provided as a first argument to it
+  :white_check_mark: beforeAll throws an error when undefined is provided as a first argument to it
+afterEach hooks error throwing
+  :white_check_mark: afterEach throws an error when "String" is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when 1 is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when [] is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when {} is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when Symbol(hello) is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when true is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when null is provided as a first argument to it
+  :white_check_mark: afterEach throws an error when undefined is provided as a first argument to it
+afterAll hooks error throwing
+  :white_check_mark: afterAll throws an error when "String" is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when 1 is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when [] is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when {} is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when Symbol(hello) is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when true is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when null is provided as a first argument to it
+  :white_check_mark: afterAll throws an error when undefined is provided as a first argument to it
+```
+### :white_check_mark: <a id="user-content-r0s298" href="#r0s298">packages/jest-jasmine2/src/__tests__/iterators.test.ts</a>
+```
+iterators
+  :white_check_mark: works for arrays
+  :white_check_mark: works for custom iterables
+  :white_check_mark: works for Sets
+  :white_check_mark: works for Maps
+```
+### :white_check_mark: <a id="user-content-r0s299" href="#r0s299">packages/jest-jasmine2/src/__tests__/itTestError.test.ts</a>
+```
+test/it error throwing
+  :white_check_mark: it throws error with missing callback function
+  :white_check_mark: it throws an error when first argument isn't a string
+  :white_check_mark: it throws an error when callback function is not a function
+  :white_check_mark: test throws error with missing callback function
+  :white_check_mark: test throws an error when first argument isn't a string
+  :white_check_mark: test throws an error when callback function is not a function
+```
+### :white_check_mark: <a id="user-content-r0s300" href="#r0s300">packages/jest-jasmine2/src/__tests__/itToTestAlias.test.ts</a>
+```
+:white_check_mark: global.test
+```
+### :white_check_mark: <a id="user-content-r0s301" href="#r0s301">packages/jest-jasmine2/src/__tests__/pTimeout.test.ts</a>
+```
+pTimeout
+  :white_check_mark: calls `clearTimeout` and resolves when `promise` resolves.
+  :white_check_mark: calls `clearTimeout` and rejects when `promise` rejects.
+  :white_check_mark: calls `onTimeout` on timeout.
+```
+### :white_check_mark: <a id="user-content-r0s302" href="#r0s302">packages/jest-jasmine2/src/__tests__/queueRunner.test.ts</a>
+```
+queueRunner
+  :white_check_mark: runs every function in the queue.
+  :white_check_mark: exposes `fail` to `next`.
+  :white_check_mark: passes errors to `onException`.
+  :white_check_mark: passes an error to `onException` on timeout.
+  :white_check_mark: calls `fail` with arguments
+  :white_check_mark: calls `fail` when done(error) is invoked
+```
+### :white_check_mark: <a id="user-content-r0s303" href="#r0s303">packages/jest-jasmine2/src/__tests__/reporter.test.ts</a>
+```
+Jasmine2Reporter
+  :white_check_mark: reports nested suites
+```
+### :white_check_mark: <a id="user-content-r0s304" href="#r0s304">packages/jest-jasmine2/src/__tests__/Suite.test.ts</a>
+```
+Suite
+  :white_check_mark: doesn't throw on addExpectationResult when there are no children
+```
+### :white_check_mark: <a id="user-content-r0s305" href="#r0s305">packages/jest-jasmine2/src/__tests__/todoError.test.ts</a>
+```
+test/it.todo error throwing
+  :white_check_mark: it throws error when given no arguments
+  :white_check_mark: it throws error when given more than one argument
+  :white_check_mark: it throws error when given none string description
+```
+### :white_check_mark: <a id="user-content-r0s306" href="#r0s306">packages/jest-leak-detector/src/__tests__/index.test.ts</a>
+```
+:white_check_mark: complains if the value is a primitive
+:white_check_mark: does not show the GC if hidden
+:white_check_mark: does not hide the GC if visible
+:white_check_mark: correctly checks simple leaks
+:white_check_mark: tests different objects
+:white_check_mark: correctly checks more complex leaks
+```
+### :white_check_mark: <a id="user-content-r0s307" href="#r0s307">packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts</a>
+```
+:white_check_mark: returns the same value for primitive or function values
+:white_check_mark: convert accessor descriptor into value descriptor
+:white_check_mark: shuold not skips non-enumerables
+:white_check_mark: copies symbols
+:white_check_mark: copies arrays as array objects
+:white_check_mark: handles cyclic dependencies
+:white_check_mark: Copy Map
+:white_check_mark: Copy cyclic Map
+:white_check_mark: return same value for built-in object type except array, map and object
+:white_check_mark: should copy object symbol key property
+:white_check_mark: should set writable, configurable to true
+```
+### :white_check_mark: <a id="user-content-r0s308" href="#r0s308">packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceableDom.test.ts</a>
+```
+:white_check_mark: should copy dom element
+:white_check_mark: should copy complex element
+```
+### :white_check_mark: <a id="user-content-r0s309" href="#r0s309">packages/jest-matcher-utils/src/__tests__/index.test.ts</a>
+```
+stringify()
+  :white_check_mark: []
+  :white_check_mark: {}
+  :white_check_mark: 1
+  :white_check_mark: 0
+  :white_check_mark: 1.5
+  :white_check_mark: null
+  :white_check_mark: undefined
+  :white_check_mark: "abc"
+  :white_check_mark: Symbol(abc)
+  :white_check_mark: NaN
+  :white_check_mark: Infinity
+  :white_check_mark: -Infinity
+  :white_check_mark: /ab\.c/gi
+  :white_check_mark: 1n
+  :white_check_mark: 0n
+  :white_check_mark: circular references
+  :white_check_mark: toJSON error
+  :white_check_mark: toJSON errors when comparing two objects
+  :white_check_mark: reduces maxDepth if stringifying very large objects
+ensureNumbers()
+  :white_check_mark: dont throw error when variables are numbers
+  :white_check_mark: throws error when expected is not a number (backward compatibility)
+  :white_check_mark: throws error when received is not a number (backward compatibility)
+ensureNumbers() with options
+  :white_check_mark: promise empty isNot false received
+  :white_check_mark: promise empty isNot true expected
+  :white_check_mark: promise rejects isNot false expected
+  :white_check_mark: promise rejects isNot true received
+  :white_check_mark: promise resolves isNot false received
+  :white_check_mark: promise resolves isNot true expected
+ensureNoExpected()
+  :white_check_mark: dont throw error when undefined
+  :white_check_mark: throws error when expected is not undefined with matcherName
+  :white_check_mark: throws error when expected is not undefined with matcherName and options
+diff
+  :white_check_mark: forwards to jest-diff
+  :white_check_mark: two booleans
+  :white_check_mark: two numbers
+  :white_check_mark: two bigints
+pluralize()
+  :white_check_mark: one
+  :white_check_mark: two
+  :white_check_mark: 20
+getLabelPrinter
+  :white_check_mark: 0 args
+  :white_check_mark: 1 empty string
+  :white_check_mark: 1 non-empty string
+  :white_check_mark: 2 equal lengths
+  :white_check_mark: 2 unequal lengths
+  :white_check_mark: returns incorrect padding if inconsistent arg is shorter
+  :white_check_mark: throws if inconsistent arg is longer
+matcherHint
+  :white_check_mark: expectedColor
+  :white_check_mark: receivedColor
+  :white_check_mark: secondArgumentColor
+```
+### :white_check_mark: <a id="user-content-r0s310" href="#r0s310">packages/jest-matcher-utils/src/__tests__/printDiffOrStringify.test.ts</a>
+```
+printDiffOrStringify
+  :white_check_mark: expected is empty and received is single line
+  :white_check_mark: expected is multi line and received is empty
+  :white_check_mark: expected and received are single line with multiple changes
+  :white_check_mark: expected and received are multi line with trailing spaces
+  :white_check_mark: has no common after clean up chaff multiline
+  :white_check_mark: has no common after clean up chaff one-line
+  :white_check_mark: object contain readonly symbol key object
+printDiffOrStringify MAX_DIFF_STRING_LENGTH
+  :white_check_mark: both are less
+  :white_check_mark: expected is more
+  :white_check_mark: received is more
+printDiffOrStringify asymmetricMatcher
+  :white_check_mark: minimal test
+  :white_check_mark: jest asymmetricMatcher
+  :white_check_mark: custom asymmetricMatcher
+  :white_check_mark: nested object
+  :white_check_mark: array
+  :white_check_mark: object in array
+  :white_check_mark: map
+  :white_check_mark: circular object
+  :white_check_mark: transitive circular
+  :white_check_mark: circular array
+  :white_check_mark: circular map
+```
+### :white_check_mark: <a id="user-content-r0s311" href="#r0s311">packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts</a>
+```
+Replaceable constructor
+  :white_check_mark: init with object
+  :white_check_mark: init with array
+  :white_check_mark: init with Map
+  :white_check_mark: init with other type should throw error
+Replaceable get
+  :white_check_mark: get object item
+  :white_check_mark: get array item
+  :white_check_mark: get Map item
+Replaceable set
+  :white_check_mark: set object item
+  :white_check_mark: set array item
+  :white_check_mark: set Map item
+Replaceable forEach
+  :white_check_mark: object forEach
+  :white_check_mark: array forEach
+  :white_check_mark: map forEach
+  :white_check_mark: forEach should ignore nonenumerable property
+Replaceable isReplaceable
+  :white_check_mark: should return true if two object types equal and support
+  :white_check_mark: should return false if two object types not equal
+  :white_check_mark: should return false if object types not support
+```
+### :white_check_mark: <a id="user-content-r0s312" href="#r0s312">packages/jest-message-util/src/__tests__/messages.test.ts</a>
+```
+:white_check_mark: should exclude jasmine from stack trace for Unix paths.
+:white_check_mark: .formatExecError()
+:white_check_mark: formatStackTrace should strip node internals
+:white_check_mark: should not exclude vendor from stack trace
+:white_check_mark: retains message in babel code frame error
+:white_check_mark: codeframe
+:white_check_mark: no codeframe
+:white_check_mark: no stack
+formatStackTrace
+  :white_check_mark: prints code frame and stacktrace
+  :white_check_mark: does not print code frame when noCodeFrame = true
+  :white_check_mark: does not print codeframe when noStackTrace = true
+```
+### :white_check_mark: <a id="user-content-r0s313" href="#r0s313">packages/jest-mock/src/__tests__/index.test.ts</a>
+```
+moduleMocker getMetadata
+  :white_check_mark: returns the function `name` property
+  :white_check_mark: mocks constant values
+  :white_check_mark: does not retrieve metadata for arrays
+  :white_check_mark: does not retrieve metadata for undefined
+  :white_check_mark: does not retrieve metadata for null
+  :white_check_mark: retrieves metadata for ES6 classes
+  :white_check_mark: retrieves synchronous function metadata
+  :white_check_mark: retrieves asynchronous function metadata
+  :white_check_mark: retrieves metadata for object literals and it's members
+  :white_check_mark: retrieves Date object metadata
+moduleMocker generateFromMetadata
+  :white_check_mark: forwards the function name property
+  :white_check_mark: fixes illegal function name properties
+  :white_check_mark: special cases the mockConstructor name
+  :white_check_mark: wont interfere with previous mocks on a shared prototype
+  :white_check_mark: does not mock non-enumerable getters
+  :white_check_mark: mocks getters of ES modules
+  :white_check_mark: mocks ES2015 non-enumerable methods
+  :white_check_mark: mocks ES2015 non-enumerable static properties and methods
+  :white_check_mark: mocks methods in all the prototype chain (null prototype)
+  :white_check_mark: does not mock methods from Object.prototype
+  :white_check_mark: does not mock methods from Object.prototype (in mock context)
+  :white_check_mark: does not mock methods from Function.prototype
+  :white_check_mark: does not mock methods from Function.prototype (in mock context)
+  :white_check_mark: does not mock methods from RegExp.prototype
+  :white_check_mark: does not mock methods from RegExp.prototype (in mock context)
+  :white_check_mark: mocks methods that are bound multiple times
+  :white_check_mark: mocks methods that are bound after mocking
+  :white_check_mark: mocks regexp instances
+  :white_check_mark: mocks functions with numeric names
+  :white_check_mark: mocks the method in the passed object itself
+  :white_check_mark: should delete previously inexistent methods when restoring
+  :white_check_mark: supports mock value returning undefined
+  :white_check_mark: supports mock value once returning undefined
+  :white_check_mark: mockReturnValueOnce mocks value just once
+  :white_check_mark: supports mocking resolvable async functions
+  :white_check_mark: supports mocking resolvable async functions only once
+  :white_check_mark: supports mocking rejectable async functions
+  :white_check_mark: supports mocking rejectable async functions only once
+  :white_check_mark: tracks thrown errors without interfering with other tracking
+  :white_check_mark: a call that throws undefined is tracked properly
+  :white_check_mark: results of recursive calls are tracked properly
+  :white_check_mark: test results of recursive calls from within the recursive call
+  :white_check_mark: call mockClear inside recursive mock
+moduleMocker generateFromMetadata mocked functions
+  :white_check_mark: tracks calls to mocks
+  :white_check_mark: tracks instances made by mocks
+  :white_check_mark: supports clearing mock calls
+  :white_check_mark: supports clearing mocks
+  :white_check_mark: supports clearing all mocks
+  :white_check_mark: supports resetting mock return values
+  :white_check_mark: supports resetting single use mock return values
+  :white_check_mark: supports resetting mock implementations
+  :white_check_mark: supports resetting single use mock implementations
+  :white_check_mark: supports resetting all mocks
+  :white_check_mark: maintains function arity
+moduleMocker generateFromMetadata return values
+  :white_check_mark: tracks return values
+  :white_check_mark: tracks mocked return values
+  :white_check_mark: supports resetting return values
+moduleMocker generateFromMetadata invocationCallOrder
+  :white_check_mark: tracks invocationCallOrder made by mocks
+  :white_check_mark: supports clearing mock invocationCallOrder
+  :white_check_mark: supports clearing all mocks invocationCallOrder
+  :white_check_mark: handles a property called `prototype`
+moduleMocker getMockImplementation
+  :white_check_mark: should mock calls to a mock function
+moduleMocker mockImplementationOnce
+  :white_check_mark: should mock constructor
+  :white_check_mark: should mock single call to a mock function
+  :white_check_mark: should fallback to default mock function when no specific mock is available
+moduleMocker
+  :white_check_mark: mockReturnValue does not override mockImplementationOnce
+  :white_check_mark: mockImplementation resets the mock
+  :white_check_mark: should recognize a mocked function
+  :white_check_mark: default mockName is jest.fn()
+  :white_check_mark: mockName sets the mock name
+  :white_check_mark: mockName gets reset by mockReset
+  :white_check_mark: mockName gets reset by mockRestore
+  :white_check_mark: mockName is not reset by mockClear
+moduleMocker spyOn
+  :white_check_mark: should work
+  :white_check_mark: should throw on invalid input
+  :white_check_mark: supports restoring all spies
+  :white_check_mark: should work with getters
+moduleMocker spyOnProperty
+  :white_check_mark: should work - getter
+  :white_check_mark: should work - setter
+  :white_check_mark: should throw on invalid input
+  :white_check_mark: supports restoring all spies
+  :white_check_mark: should work with getters on the prototype chain
+  :white_check_mark: should work with setters on the prototype chain
+  :white_check_mark: supports restoring all spies on the prototype chain
+```
+### :white_check_mark: <a id="user-content-r0s314" href="#r0s314">packages/jest-regex-util/src/__tests__/index.test.ts</a>
+```
+replacePathSepForRegex() posix
+  :white_check_mark: should return the path
+replacePathSepForRegex() win32
+  :white_check_mark: should replace POSIX path separators
+  :white_check_mark: should escape Windows path separators
+  :white_check_mark: should not escape an escaped dot
+  :white_check_mark: should not escape an escaped regexp symbol
+  :white_check_mark: should escape Windows path separators inside groups
+  :white_check_mark: should escape Windows path separator at the beginning
+  :white_check_mark: should not escape several already escaped path separators
+```
+### :white_check_mark: <a id="user-content-r0s315" href="#r0s315">packages/jest-repl/src/__tests__/jest_repl.test.js</a>
+```
+Repl cli
+  :white_check_mark: runs without errors
+```
+### :white_check_mark: <a id="user-content-r0s316" href="#r0s316">packages/jest-repl/src/__tests__/runtime_cli.test.js</a>
+```
+Runtime CLI
+  :white_check_mark: fails with no path
+  :white_check_mark: displays script output
+  :white_check_mark: always disables automocking
+  :white_check_mark: throws script errors
+```
+### :white_check_mark: <a id="user-content-r0s317" href="#r0s317">packages/jest-reporters/src/__tests__/CoverageReporter.test.js</a>
+```
+onRunComplete
+  :white_check_mark: getLastError() returns an error when threshold is not met for global
+  :white_check_mark: getLastError() returns an error when threshold is not met for file
+  :white_check_mark: getLastError() returns `undefined` when threshold is met
+  :white_check_mark: getLastError() returns an error when threshold is not met for non-covered file
+  :white_check_mark: getLastError() returns an error when threshold is not met for directory
+  :white_check_mark: getLastError() returns `undefined` when threshold is met for directory
+  :white_check_mark: getLastError() returns an error when there is no coverage data for a threshold
+  :white_check_mark: getLastError() returns 'undefined' when global threshold group
+   is empty because PATH and GLOB threshold groups have matched all the
+    files in the coverage data.
+  :white_check_mark: getLastError() returns 'undefined' when file and directory path
+  threshold groups overlap
+  :white_check_mark: that if globs or paths are specified alongside global, coverage
+  data for matching paths will be subtracted from overall coverage
+  and thresholds will be applied independently
+  :white_check_mark: that files are matched by all matching threshold groups
+  :white_check_mark: that it passes custom options when creating reporters
+```
+### :white_check_mark: <a id="user-content-r0s318" href="#r0s318">packages/jest-reporters/src/__tests__/CoverageWorker.test.js</a>
+```
+:white_check_mark: resolves to the result of generateEmptyCoverage upon success
+:white_check_mark: throws errors on invalid JavaScript
+```
+### :white_check_mark: <a id="user-content-r0s319" href="#r0s319">packages/jest-reporters/src/__tests__/DefaultReporter.test.js</a>
+```
+:white_check_mark: normal output, everything goes to stdout
+:white_check_mark: when using stderr as output, no stdout call is made
+```
+### :white_check_mark: <a id="user-content-r0s320" href="#r0s320">packages/jest-reporters/src/__tests__/generateEmptyCoverage.test.js</a>
+```
+generateEmptyCoverage
+  :white_check_mark: generates an empty coverage object for a file without running it
+  :white_check_mark: generates a null coverage result when using /* istanbul ignore file */
+  :white_check_mark: generates a null coverage result when collectCoverage global config is false
+```
+### :white_check_mark: <a id="user-content-r0s321" href="#r0s321">packages/jest-reporters/src/__tests__/getResultHeader.test.js</a>
+```
+:white_check_mark: should call `terminal-link` correctly
+:white_check_mark: should render the terminal link
+:white_check_mark: should display test time for slow test
+:white_check_mark: should not display test time for fast test
+```
+### :white_check_mark: <a id="user-content-r0s322" href="#r0s322">packages/jest-reporters/src/__tests__/getSnapshotStatus.test.js</a>
+```
+:white_check_mark: Retrieves the snapshot status
+:white_check_mark: Shows no snapshot updates if all snapshots matched
+:white_check_mark: Retrieves the snapshot status after a snapshot update
+```
+### :white_check_mark: <a id="user-content-r0s323" href="#r0s323">packages/jest-reporters/src/__tests__/getSnapshotSummary.test.js</a>
+```
+:white_check_mark: creates a snapshot summary
+:white_check_mark: creates a snapshot summary after an update
+:white_check_mark: creates a snapshot summary with multiple snapshot being written/updated
+:white_check_mark: returns nothing if there are no updates
+```
+### :white_check_mark: <a id="user-content-r0s324" href="#r0s324">packages/jest-reporters/src/__tests__/getWatermarks.test.ts</a>
+```
+getWatermarks
+  :white_check_mark: that watermarks use thresholds as upper target
+  :white_check_mark: that watermarks are created always created
+```
+### :white_check_mark: <a id="user-content-r0s325" href="#r0s325">packages/jest-reporters/src/__tests__/NotifyReporter.test.ts</a>
+```
+:white_check_mark: test always
+:white_check_mark: test success
+:white_check_mark: test change
+:white_check_mark: test success-change
+:white_check_mark: test failure-change
+:white_check_mark: test always with rootDir
+:white_check_mark: test success with rootDir
+:white_check_mark: test change with rootDir
+:white_check_mark: test success-change with rootDir
+:white_check_mark: test failure-change with rootDir
+:white_check_mark: test always with moduleName
+:white_check_mark: test success with moduleName
+:white_check_mark: test change with moduleName
+:white_check_mark: test success-change with moduleName
+:white_check_mark: test failure-change with moduleName
+node-notifier is an optional dependency
+  :white_check_mark: without node-notifier uses mock function that throws an error
+  :white_check_mark: throws the error when require throws an unexpected error
+  :white_check_mark: uses node-notifier when it is available
+```
+### :white_check_mark: <a id="user-content-r0s326" href="#r0s326">packages/jest-reporters/src/__tests__/SummaryReporter.test.js</a>
+```
+:white_check_mark: snapshots needs update with npm test
+:white_check_mark: snapshots needs update with yarn test
+:white_check_mark: snapshots all have results (no update)
+:white_check_mark: snapshots all have results (after update)
+```
+### :white_check_mark: <a id="user-content-r0s327" href="#r0s327">packages/jest-reporters/src/__tests__/utils.test.ts</a>
+```
+wrapAnsiString()
+  :white_check_mark: wraps a long string containing ansi chars
+  :white_check_mark: returns the string unaltered if given a terminal width of zero
+trimAndFormatPath()
+  :white_check_mark: trims dirname
+  :white_check_mark: trims dirname (longer line width)
+  :white_check_mark: trims dirname and basename
+  :white_check_mark: does not trim anything
+  :white_check_mark: split at the path.sep index
+printDisplayName
+  :white_check_mark: should default displayName color to white when displayName is a string
+  :white_check_mark: should default displayName color to white when color is not a valid value
+  :white_check_mark: should correctly print the displayName when color and name are valid values
+```
+### :white_check_mark: <a id="user-content-r0s328" href="#r0s328">packages/jest-reporters/src/__tests__/VerboseReporter.test.js</a>
+```
+groupTestsBySuites
+  :white_check_mark: should handle empty results
+  :white_check_mark: should group A1 in A
+  :white_check_mark: should group A1 in A; B1 in B
+  :white_check_mark: should group A1, A2 in A
+  :white_check_mark: should group A1, A2 in A; B1, B2 in B
+  :white_check_mark: should group AB1 in AB
+  :white_check_mark: should group AB1, AB2 in AB
+  :white_check_mark: should group A1 in A; AB1 in AB
+  :white_check_mark: should group AB1 in AB; A1 in A
+  :white_check_mark: should group AB1 in AB; CD1 in CD
+  :white_check_mark: should group ABC1 in ABC; BC1 in BC; D1 in D; A1 in A
+```
+### :white_check_mark: <a id="user-content-r0s329" href="#r0s329">packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts</a>
+```
+:white_check_mark: resolves no dependencies for non-existent path
+:white_check_mark: resolves dependencies for existing path
+:white_check_mark: includes the mocks of dependencies as dependencies
+:white_check_mark: resolves dependencies for scoped packages
+:white_check_mark: resolves no inverse dependencies for empty paths set
+:white_check_mark: resolves no inverse dependencies for set of non-existent paths
+:white_check_mark: resolves inverse dependencies for existing path
+:white_check_mark: resolves inverse dependencies of mock
+:white_check_mark: resolves inverse dependencies from available snapshot
+:white_check_mark: resolves dependencies correctly when dependency resolution fails
+:white_check_mark: resolves dependencies correctly when mock dependency resolution fails
+```
+### :white_check_mark: <a id="user-content-r0s330" href="#r0s330">packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts</a>
+```
+isBuiltinModule
+  :white_check_mark: should return true for the `path` module
+  :white_check_mark: should return false for the `chalk` module
+  :white_check_mark: should return true for the `_http_common` module
+  :white_check_mark: should return false for any internal node builtins
+```
+### :white_check_mark: <a id="user-content-r0s331" href="#r0s331">packages/jest-resolve/src/__tests__/resolve.test.ts</a>
+```
+isCoreModule
+  :white_check_mark: returns false if `hasCoreModules` is false.
+  :white_check_mark: returns true if `hasCoreModules` is true and `moduleName` is a core module.
+  :white_check_mark: returns false if `hasCoreModules` is true and `moduleName` is not a core module.
+  :white_check_mark: returns false if `hasCoreModules` is true and `moduleNameMapper` alias a module same name with core module
+findNodeModule
+  :white_check_mark: is possible to override the default resolver
+  :white_check_mark: passes packageFilter to the resolve module when using the default resolver
+resolveModule
+  :white_check_mark: is possible to resolve node modules
+  :white_check_mark: is possible to resolve node modules with custom extensions
+  :white_check_mark: is possible to resolve node modules with custom extensions and platforms
+  :white_check_mark: is possible to resolve node modules by resolving their realpath
+  :white_check_mark: is possible to specify custom resolve paths
+  :white_check_mark: does not confuse directories with files
+getMockModule
+  :white_check_mark: is possible to use custom resolver to resolve deps inside mock modules with moduleNameMapper
+nodeModulesPaths
+  :white_check_mark: provides custom module paths after node_modules
+Resolver.getModulePaths() -> nodeModulesPaths()
+  :white_check_mark: can resolve node modules relative to absolute paths in "moduleDirectories" on Windows platforms
+  :white_check_mark: can resolve node modules relative to absolute paths in "moduleDirectories" on Posix platforms
+```
+### :white_check_mark: <a id="user-content-r0s332" href="#r0s332">packages/jest-runner/src/__tests__/testRunner.test.ts</a>
+```
+:white_check_mark: injects the serializable module map into each worker in watch mode
+:white_check_mark: assign process.env.JEST_WORKER_ID = 1 when in runInBand mode
+```
+### :white_check_mark: <a id="user-content-r0s333" href="#r0s333">packages/jest-runtime/src/__tests__/instrumentation.test.ts</a>
+```
+:white_check_mark: instruments files
+```
+### :white_check_mark: <a id="user-content-r0s334" href="#r0s334">packages/jest-runtime/src/__tests__/runtime_create_mock_from_module.test.js</a>
+```
+Runtime createMockFromModule
+  :white_check_mark: does not cause side effects in the rest of the module system when generating a mock
+  :white_check_mark: resolves mapped modules correctly
+Runtime
+  :white_check_mark: creates mock objects in the right environment
+```
+### :white_check_mark: <a id="user-content-r0s335" href="#r0s335">packages/jest-runtime/src/__tests__/runtime_environment.test.js</a>
+```
+Runtime requireModule
+  :white_check_mark: emulates a node stack trace during module load
+  :white_check_mark: emulates a node stack trace during function execution
+```
+### :white_check_mark: <a id="user-content-r0s336" href="#r0s336">packages/jest-runtime/src/__tests__/runtime_internal_module.test.js</a>
+```
+Runtime internalModule
+  :white_check_mark: loads modules and applies transforms
+  :white_check_mark: loads internal modules without applying transforms
+  :white_check_mark: loads JSON modules and applies transforms
+  :white_check_mark: loads internal JSON modules without applying transforms
+```
+### :white_check_mark: <a id="user-content-r0s337" href="#r0s337">packages/jest-runtime/src/__tests__/runtime_jest_fn.js</a>
+```
+Runtime jest.fn
+  :white_check_mark: creates mock functions
+  :white_check_mark: creates mock functions with mock implementations
+Runtime jest.isMockFunction
+  :white_check_mark: recognizes a mocked function
+Runtime jest.clearAllMocks
+  :white_check_mark: clears all mocks
+```
+### :white_check_mark: <a id="user-content-r0s338" href="#r0s338">packages/jest-runtime/src/__tests__/runtime_jest_spy_on.test.js</a>
+```
+Runtime jest.spyOn
+  :white_check_mark: calls the original function
+Runtime jest.spyOnProperty
+  :white_check_mark: calls the original function
+```
+### :white_check_mark: <a id="user-content-r0s339" href="#r0s339">packages/jest-runtime/src/__tests__/runtime_mock.test.js</a>
+```
+Runtime jest.mock
+  :white_check_mark: uses explicitly set mocks instead of automocking
+  :white_check_mark: sets virtual mock for non-existing module required from same directory
+  :white_check_mark: sets virtual mock for non-existing module required from different directory
+Runtime jest.setMock
+  :white_check_mark: uses explicitly set mocks instead of automocking
+```
+### :white_check_mark: <a id="user-content-r0s340" href="#r0s340">packages/jest-runtime/src/__tests__/runtime_module_directories.test.js</a>
+```
+Runtime
+  :white_check_mark: uses configured moduleDirectories
+  :white_check_mark: resolves packages
+  :white_check_mark: finds closest module from moduleDirectories
+  :white_check_mark: only checks the configured directories
+```
+### :white_check_mark: <a id="user-content-r0s341" href="#r0s341">packages/jest-runtime/src/__tests__/runtime_node_path.test.js</a>
+```
+Runtime
+  :white_check_mark: uses NODE_PATH to find modules
+  :white_check_mark: uses modulePaths to find modules
+  :white_check_mark: finds modules in NODE_PATH containing multiple paths
+  :white_check_mark: does not find modules if NODE_PATH is relative
+```
+### :white_check_mark: <a id="user-content-r0s342" href="#r0s342">packages/jest-runtime/src/__tests__/runtime_require_actual.test.js</a>
+```
+Runtime requireActual
+  :white_check_mark: requires node module when manual mock exists
+  :white_check_mark: requireActual with moduleNameMapper
+```
+### :white_check_mark: <a id="user-content-r0s343" href="#r0s343">packages/jest-runtime/src/__tests__/runtime_require_cache.test.js</a>
+```
+Runtime require.cache
+  :white_check_mark: require.cache returns loaded module list as native Nodejs require does
+  :white_check_mark: require.cache is tolerant readonly
+```
+### :white_check_mark: <a id="user-content-r0s344" href="#r0s344">packages/jest-runtime/src/__tests__/runtime_require_mock.test.js</a>
+```
+Runtime requireMock
+  :white_check_mark: uses manual mocks before attempting to automock
+  :white_check_mark: can resolve modules that are only referenced from mocks
+  :white_check_mark: stores and re-uses manual mock exports
+  :white_check_mark: automocks haste modules without a manual mock
+  :white_check_mark: automocks relative-path modules without a file extension
+  :white_check_mark: automocks relative-path modules with a file extension
+  :white_check_mark: just falls back when loading a native module
+  :white_check_mark: stores and re-uses automocked haste exports
+  :white_check_mark: stores and re-uses automocked relative-path modules
+  :white_check_mark: multiple node core modules returns correct module
+  :white_check_mark: throws on non-existent haste modules
+  :white_check_mark: uses manual mocks when using a custom resolver
+  :white_check_mark: provides `require.main` in mock
+```
+### :white_check_mark: <a id="user-content-r0s345" href="#r0s345">packages/jest-runtime/src/__tests__/runtime_require_module_no_ext.test.js</a>
+```
+Runtime requireModule with no extension
+  :white_check_mark: throws error pointing out file with extension
+```
+### :white_check_mark: <a id="user-content-r0s346" href="#r0s346">packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js</a>
+```
+transitive dependencies
+  :white_check_mark: mocks a manually mocked and mapped module
+  :white_check_mark: unmocks transitive dependencies in node_modules by default
+  :white_check_mark: unmocks transitive dependencies in node_modules when using unmock
+  :white_check_mark: unmocks transitive dependencies in node_modules by default when using both patterns and unmock
+  :white_check_mark: mocks deep dependencies when using unmock
+  :white_check_mark: does not mock deep dependencies when using deepUnmock
+```
+### :white_check_mark: <a id="user-content-r0s347" href="#r0s347">packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js</a>
+```
+:white_check_mark: mocks modules by default when using automocking
+:white_check_mark: doesn't mock modules when explicitly unmocked when using automocking
+:white_check_mark: doesn't mock modules when explicitly unmocked via a different name
+:white_check_mark: doesn't mock modules when disableAutomock() has been called
+:white_check_mark: uses manual mock when automocking on and mock is available
+:white_check_mark: does not use manual mock when automocking is off and a real module is available
+:white_check_mark: resolves mapped module names and unmocks them by default
+:white_check_mark: automocking is disabled by default
+:white_check_mark: unmocks modules in config.unmockedModulePathPatterns for tests with automock enabled when automock is false
+:white_check_mark: unmocks virtual mocks after they have been mocked previously
+resetModules
+  :white_check_mark: resets all the modules
+isolateModules
+  :white_check_mark: keeps it's registry isolated from global one
+  :white_check_mark: resets all modules after the block
+  :white_check_mark: resets module after failing
+  :white_check_mark: cannot nest isolateModules blocks
+  :white_check_mark: can call resetModules within a isolateModules block
+isolateModules can use isolateModules from a beforeEach block
+  :white_check_mark: can use the required module from beforeEach and re-require it
+```
+### :white_check_mark: <a id="user-content-r0s348" href="#r0s348">packages/jest-runtime/src/__tests__/runtime_require_module.test.js</a>
+```
+Runtime requireModule
+  :white_check_mark: finds haste modules
+  :white_check_mark: provides `module` to modules
+  :white_check_mark: provides `module.parent` to modules
+  :white_check_mark: `module.parent` should be undefined for entrypoints
+  :white_check_mark: resolve module.parent.require correctly
+  :white_check_mark: resolve module.parent.filename correctly
+  :white_check_mark: provides `module.loaded` to modules
+  :white_check_mark: provides `module.filename` to modules
+  :white_check_mark: provides `module.paths` to modules
+  :white_check_mark: provides `require.main` to modules
+  :white_check_mark: throws on non-existent haste modules
+  :white_check_mark: finds relative-path modules without file extension
+  :white_check_mark: finds relative-path modules with file extension
+  :white_check_mark: throws on non-existent relative-path modules
+  :white_check_mark: finds node core built-in modules
+  :white_check_mark: finds and loads JSON files without file extension
+  :white_check_mark: finds and loads JSON files with file extension
+  :white_check_mark: requires a JSON file twice successfully
+  :white_check_mark: provides manual mock when real module doesnt exist
+  :white_check_mark: doesn't override real modules with manual mocks when explicitly unmocked
+  :white_check_mark: resolves haste packages properly
+  :white_check_mark: resolves platform extensions based on the default platform
+  :white_check_mark: finds modules encoded in UTF-8 *with BOM*
+  :white_check_mark: finds and loads JSON files encoded in UTF-8 *with BOM*
+  :white_check_mark: should export a constructable Module class
+  :white_check_mark: caches Module correctly
+Runtime requireModule on node >=12.12.0
+  :white_check_mark: overrides module.createRequire
+```
+### :white_check_mark: <a id="user-content-r0s349" href="#r0s349">packages/jest-runtime/src/__tests__/runtime_require_resolve.test.ts</a>
+```
+Runtime require.resolve
+  :white_check_mark: resolves a module path
+  :white_check_mark: resolves a module path with moduleNameMapper
+Runtime require.resolve with the jest-resolve-outside-vm-option
+  :white_check_mark: forwards to the real Node require in an internal context
+  :white_check_mark: ignores the option in an external context
+  :white_check_mark: does not understand a self-constructed outsideJestVmPath in an external context
+```
+### :white_check_mark: <a id="user-content-r0s350" href="#r0s350">packages/jest-runtime/src/__tests__/runtime_wrap.js</a>
+```
+Runtime wrapCodeInModuleWrapper
+  :white_check_mark: generates the correct args for the module wrapper
+  :white_check_mark: injects "extra globals"
+```
+### :white_check_mark: <a id="user-content-r0s351" href="#r0s351">packages/jest-runtime/src/__tests__/Runtime-sourceMaps.test.js</a>
+```
+Runtime requireModule
+  :white_check_mark: installs source maps if available
+```
+### :white_check_mark: <a id="user-content-r0s352" href="#r0s352">packages/jest-runtime/src/__tests__/Runtime-statics.test.js</a>
+```
+Runtime statics
+  :white_check_mark: Runtime.createHasteMap passes correct ignore files to HasteMap
+  :white_check_mark: Runtime.createHasteMap passes correct ignore files to HasteMap in watch mode
+```
+### :white_check_mark: <a id="user-content-r0s353" href="#r0s353">packages/jest-serializer/src/__tests__/index.test.ts</a>
+```
+Using V8 implementation
+  :white_check_mark: throws the error with an invalid serialization
+Using V8 implementation Object 0
+  :white_check_mark: serializes/deserializes in memory
+  :white_check_mark: serializes/deserializes in disk
+Using V8 implementation Object 1
+  :white_check_mark: serializes/deserializes in memory
+  :white_check_mark: serializes/deserializes in disk
+Using V8 implementation Object 2
+  :white_check_mark: serializes/deserializes in memory
+  :white_check_mark: serializes/deserializes in disk
+Using V8 implementation Object 3
+  :white_check_mark: serializes/deserializes in memory
+  :white_check_mark: serializes/deserializes in disk
+Using V8 implementation Object 4
+  :white_check_mark: serializes/deserializes in memory
+  :white_check_mark: serializes/deserializes in disk
+Using V8 implementation Object 5
+  :white_check_mark: serializes/deserializes in memory
+  :white_check_mark: serializes/deserializes in disk
+Using V8 implementation Object 6
+  :white_check_mark: serializes/deserializes in memory
+  :white_check_mark: serializes/deserializes in disk
+Using V8 implementation Object 7
+  :white_check_mark: serializes/deserializes in memory
+  :white_check_mark: serializes/deserializes in disk
+```
+### :white_check_mark: <a id="user-content-r0s354" href="#r0s354">packages/jest-snapshot/src/__tests__/dedentLines.test.ts</a>
+```
+dedentLines non-null
+  :white_check_mark: no lines
+  :white_check_mark: one line empty string
+  :white_check_mark: one line empty object
+  :white_check_mark: one line self-closing element
+  :white_check_mark: object value empty string
+  :white_check_mark: object value string includes double-quote marks
+  :white_check_mark: markup with props and text
+  :white_check_mark: markup with components as props
+dedentLines null
+  :white_check_mark: object key multi-line
+  :white_check_mark: object value multi-line
+  :white_check_mark: object key and value multi-line
+  :white_check_mark: markup prop multi-line
+  :white_check_mark: markup prop component with multi-line text
+  :white_check_mark: markup text multi-line
+  :white_check_mark: markup text multiple lines
+  :white_check_mark: markup unclosed self-closing start tag
+  :white_check_mark: markup unclosed because no end tag
+```
+### :white_check_mark: <a id="user-content-r0s355" href="#r0s355">packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts</a>
+```
+:white_check_mark: saveInlineSnapshots() replaces empty function call with a template literal
+:white_check_mark: saveInlineSnapshots() without prettier leaves formatting outside of snapshots alone
+:white_check_mark: saveInlineSnapshots() can handle typescript without prettier
+:white_check_mark: saveInlineSnapshots() can handle tsx without prettier
+:white_check_mark: saveInlineSnapshots() can handle flow and jsx without prettier
+:white_check_mark: saveInlineSnapshots() can use prettier to fix formatting for whole file
+:white_check_mark: saveInlineSnapshots() replaces existing template literal - babel parser
+:white_check_mark: saveInlineSnapshots() replaces existing template literal - flow parser
+:white_check_mark: saveInlineSnapshots() replaces existing template literal - typescript parser
+:white_check_mark: saveInlineSnapshots() replaces existing template literal with property matchers
+:white_check_mark: saveInlineSnapshots() creates template literal with property matchers
+:white_check_mark: saveInlineSnapshots() creates template literal with property matchers
+:white_check_mark: saveInlineSnapshots() throws if frame does not match
+:white_check_mark: saveInlineSnapshots() throws if multiple calls to to the same location
+:white_check_mark: saveInlineSnapshots() uses escaped backticks
+:white_check_mark: saveInlineSnapshots() works with non-literals in expect call
+:white_check_mark: saveInlineSnapshots() indents multi-line snapshots with spaces
+:white_check_mark: saveInlineSnapshots() does not re-indent error snapshots
+:white_check_mark: saveInlineSnapshots() does not re-indent already indented snapshots
+:white_check_mark: saveInlineSnapshots() indents multi-line snapshots with tabs
+:white_check_mark: saveInlineSnapshots() indents snapshots after prettier reformats
+:white_check_mark: saveInlineSnapshots() does not indent empty lines
+```
+### :white_check_mark: <a id="user-content-r0s356" href="#r0s356">packages/jest-snapshot/src/__tests__/matcher.test.ts</a>
+```
+:white_check_mark: matcher returns matcher name, expected and actual values
+```
+### :white_check_mark: <a id="user-content-r0s357" href="#r0s357">packages/jest-snapshot/src/__tests__/mockSerializer.test.ts</a>
+```
+:white_check_mark: mock with 0 calls and default name
+:white_check_mark: mock with 2 calls, 1 return, 1 throw
+:white_check_mark: mock with 0 calls and default name in React element
+:white_check_mark: mock with 0 calls and non-default name
+:white_check_mark: mock with 1 calls and non-default name via new in object
+:white_check_mark: mock with 1 calls in React element
+:white_check_mark: mock with 2 calls
+:white_check_mark: indent option
+:white_check_mark: min option
+:white_check_mark: maxDepth option
+```
+### :white_check_mark: <a id="user-content-r0s358" href="#r0s358">packages/jest-snapshot/src/__tests__/printSnapshot.test.ts</a>
+```
+chalk
+  :white_check_mark: level 0
+  :white_check_mark: level 1
+  :white_check_mark: level 2
+  :white_check_mark: level 3
+matcher error toMatchInlineSnapshot
+  :white_check_mark: Expected properties must be an object (non-null) without snapshot
+  :white_check_mark: Expected properties must be an object (null) with snapshot
+  :white_check_mark: Inline snapshot must be a string
+  :white_check_mark: Snapshot matchers cannot be used with not
+matcher error toMatchSnapshot
+  :white_check_mark: Expected properties must be an object (non-null)
+  :white_check_mark: Expected properties must be an object (null) with hint
+  :white_check_mark: Expected properties must be an object (null) without hint
+  :white_check_mark: Snapshot state must be initialized
+matcher error toMatchSnapshot received value must be an object
+  :white_check_mark: (non-null)
+  :white_check_mark: (null)
+matcher error toThrowErrorMatchingInlineSnapshot
+  :white_check_mark: Inline snapshot must be a string
+  :white_check_mark: Snapshot state must be initialized
+matcher error toThrowErrorMatchingSnapshot
+  :white_check_mark: Received value must be a function
+  :white_check_mark: Snapshot matchers cannot be used with not
+other error toThrowErrorMatchingSnapshot
+  :white_check_mark: Received function did not throw
+pass false toMatchInlineSnapshot with properties equals false
+  :white_check_mark: with snapshot
+  :white_check_mark: without snapshot
+pass false toMatchInlineSnapshot with properties
+  :white_check_mark: equals true
+pass false toMatchSnapshot
+  :white_check_mark: New snapshot was not written (multi line)
+  :white_check_mark: New snapshot was not written (single line)
+pass false toMatchSnapshot with properties equals false
+  :white_check_mark: isLineDiffable false
+  :white_check_mark: isLineDiffable true
+pass false toMatchSnapshot with properties
+  :white_check_mark: equals true
+pass false toThrowErrorMatchingInlineSnapshot
+  :white_check_mark: with snapshot
+pass true toMatchSnapshot
+  :white_check_mark: without properties
+printPropertiesAndReceived
+  :white_check_mark: omit missing properties
+printSnapshotAndReceived backtick
+  :white_check_mark: single line expected and received
+printSnapshotAndReceived empty string
+  :white_check_mark: expected and received single line
+  :white_check_mark: received and expected multi line
+printSnapshotAndReceived escape
+  :white_check_mark: double quote marks in string
+  :white_check_mark: backslash in multi line string
+  :white_check_mark: backslash in single line string
+  :white_check_mark: regexp
+printSnapshotAndReceived expand
+  :white_check_mark: false
+  :white_check_mark: true
+printSnapshotAndReceived
+  :white_check_mark: fallback to line diff
+  :white_check_mark: multi line small change in one line and other is unchanged
+  :white_check_mark: multi line small changes
+  :white_check_mark: single line large changes
+printSnapshotAndReceived has no common after clean up chaff
+  :white_check_mark: array
+  :white_check_mark: string single line
+printSnapshotAndReceived MAX_DIFF_STRING_LENGTH unquoted
+  :white_check_mark: both are less
+  :white_check_mark: expected is more
+  :white_check_mark: received is more
+printSnapshotAndReceived MAX_DIFF_STRING_LENGTH quoted
+  :white_check_mark: both are less
+  :white_check_mark: expected is more
+  :white_check_mark: received is more
+printSnapshotAndReceived isLineDiffable false
+  :white_check_mark: asymmetric matcher
+  :white_check_mark: boolean
+  :white_check_mark: date
+  :white_check_mark: error
+  :white_check_mark: function
+  :white_check_mark: number
+printSnapshotAndReceived isLineDiffable true
+  :white_check_mark: array
+  :white_check_mark: object
+  :white_check_mark: single line expected and received
+  :white_check_mark: single line expected and multi line received
+printSnapshotAndReceived ignore indentation
+  :white_check_mark: markup delete
+  :white_check_mark: markup fall back
+  :white_check_mark: markup insert
+printSnapshotAndReceived ignore indentation object
+  :white_check_mark: delete
+  :white_check_mark: insert
+printSnapshotAndReceived without serialize
+  :white_check_mark: backtick single line expected and received
+  :white_check_mark: backtick single line expected and multi line received
+  :white_check_mark: has no common after clean up chaff multi line
+  :white_check_mark: has no common after clean up chaff single line
+  :white_check_mark: prettier/pull/5590
+```
+### :white_check_mark: <a id="user-content-r0s359" href="#r0s359">packages/jest-snapshot/src/__tests__/SnapshotResolver.test.ts</a>
+```
+defaults
+  :white_check_mark: returns cached object if called multiple times
+  :white_check_mark: resolveSnapshotPath()
+  :white_check_mark: resolveTestPath()
+custom resolver in project config
+  :white_check_mark: returns cached object if called multiple times
+  :white_check_mark: resolveSnapshotPath()
+  :white_check_mark: resolveTestPath()
+malformed custom resolver in project config
+  :white_check_mark: missing resolveSnapshotPath throws
+  :white_check_mark: missing resolveTestPath throws
+  :white_check_mark: missing testPathForConsistencyCheck throws
+  :white_check_mark: inconsistent functions throws
+```
+### :white_check_mark: <a id="user-content-r0s360" href="#r0s360">packages/jest-snapshot/src/__tests__/throwMatcher.test.ts</a>
+```
+:white_check_mark: throw matcher can take func
+throw matcher from promise
+  :white_check_mark: can take error
+  :white_check_mark: can take custom error
+```
+### :white_check_mark: <a id="user-content-r0s361" href="#r0s361">packages/jest-snapshot/src/__tests__/utils.test.ts</a>
+```
+:white_check_mark: keyToTestName()
+:white_check_mark: testNameToKey
+:white_check_mark: saveSnapshotFile() works with
+:white_check_mark: saveSnapshotFile() works with
+:white_check_mark: getSnapshotData() throws when no snapshot version
+:white_check_mark: getSnapshotData() throws for older snapshot version
+:white_check_mark: getSnapshotData() throws for newer snapshot version
+:white_check_mark: getSnapshotData() does not throw for when updating
+:white_check_mark: getSnapshotData() marks invalid snapshot dirty when updating
+:white_check_mark: getSnapshotData() marks valid snapshot not dirty when updating
+:white_check_mark: escaping
+:white_check_mark: serialize handles \r\n
+ExtraLineBreaks
+  :white_check_mark: 0 empty string
+  :white_check_mark: 1 line has double quote marks at edges
+  :white_check_mark: 1 line has spaces at edges
+  :white_check_mark: 2 lines both are blank
+  :white_check_mark: 2 lines have double quote marks at edges
+  :white_check_mark: 2 lines first is blank
+  :white_check_mark: 2 lines last is blank
+removeLinesBeforeExternalMatcherTrap
+  :white_check_mark: contains external matcher trap
+  :white_check_mark: doesn't contain external matcher trap
+DeepMerge with property matchers
+  :white_check_mark: Correctly merges a nested object
+  :white_check_mark: Correctly merges an object with an array of objects
+  :white_check_mark: Correctly merges an object with an array of strings
+  :white_check_mark: Correctly merges an array of objects
+  :white_check_mark: Correctly merges an array of arrays
+```
+### :white_check_mark: <a id="user-content-r0s362" href="#r0s362">packages/jest-source-map/src/__tests__/getCallsite.test.ts</a>
+```
+getCallsite
+  :white_check_mark: without source map
+  :white_check_mark: ignores errors when fs throws
+  :white_check_mark: reads source map file to determine line and column
+```
+### :white_check_mark: <a id="user-content-r0s363" href="#r0s363">packages/jest-test-result/src/__tests__/formatTestResults.test.ts</a>
+```
+formatTestResults
+  :white_check_mark: includes test full name
+```
+### :white_check_mark: <a id="user-content-r0s364" href="#r0s364">packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js</a>
+```
+:white_check_mark: sorts by file size if there is no timing information
+:white_check_mark: sorts based on timing information
+:white_check_mark: sorts based on failures and timing information
+:white_check_mark: sorts based on failures, timing information and file size
+:white_check_mark: writes the cache based on results without existing cache
+:white_check_mark: returns failed tests in sorted order
+:white_check_mark: writes the cache based on the results
+:white_check_mark: works with multiple contexts
+```
+### :white_check_mark: <a id="user-content-r0s365" href="#r0s365">packages/jest-transform/src/__tests__/ScriptTransformer.test.ts</a>
+```
+ScriptTransformer
+  :white_check_mark: transforms a file properly
+  :white_check_mark: does not transform Node core modules
+  :white_check_mark: throws an error if `process` doesn't return a string or an objectcontaining `code` key with processed string
+  :white_check_mark: throws an error if `process` doesn't defined
+  :white_check_mark: throws an error if createTransformer returns object without `process` method
+  :white_check_mark: shouldn't throw error without process method. But with corrent createTransformer method
+  :white_check_mark: uses the supplied preprocessor
+  :white_check_mark: uses multiple preprocessors
+  :white_check_mark: writes source map if preprocessor supplies it
+  :white_check_mark: writes source map if preprocessor inlines it
+  :white_check_mark: warns of unparseable inlined source maps from the preprocessor
+  :white_check_mark: writes source maps if given by the transformer
+  :white_check_mark: does not write source map if not given by the transformer
+  :white_check_mark: should write a source map for the instrumented file when transformed
+  :white_check_mark: should write a source map for the instrumented file when not transformed
+  :white_check_mark: passes expected transform options to getCacheKey
+  :white_check_mark: creates transformer with config
+  :white_check_mark: reads values from the cache
+  :white_check_mark: reads values from the cache when the file contains colons
+  :white_check_mark: should reuse the value from in-memory cache which is set by custom transformer
+  :white_check_mark: does not reuse the in-memory cache between different projects
+  :white_check_mark: preload transformer when using `preloadTransformer`
+```
+### :white_check_mark: <a id="user-content-r0s366" href="#r0s366">packages/jest-transform/src/__tests__/shouldInstrument.test.ts</a>
+```
+shouldInstrument should return true
+  :white_check_mark: when testRegex is provided and file is not a test file
+  :white_check_mark: when more than one testRegex is provided and filename is not a test file
+  :white_check_mark: when testMatch is provided and file is not a test file
+  :white_check_mark: when testPathIgnorePatterns is provided and file is not a test file
+  :white_check_mark: when more than one testPathIgnorePatterns is provided and filename is not a test file
+  :white_check_mark: when testRegex and testPathIgnorePatterns are provided and file is not a test file
+  :white_check_mark: when testMatch and testPathIgnorePatterns are provided and file is not a test file
+  :white_check_mark: should return true when file is in collectCoverageOnlyFrom when provided
+  :white_check_mark: should return true when filename matches collectCoverageFrom
+  :white_check_mark: should return true if the file is not in coveragePathIgnorePatterns
+  :white_check_mark: should return true if file is a testfile but forceCoverageMatch is set
+shouldInstrument should return false
+  :white_check_mark: if collectCoverage is falsy
+  :white_check_mark: when testRegex is provided and filename is a test file
+  :white_check_mark: when more than one testRegex is provided and filename matches one of the patterns
+  :white_check_mark: when testMatch is provided and file is a test file
+  :white_check_mark: when testRegex and testPathIgnorePatterns are provided and filename is a test file
+  :white_check_mark: when testMatch and testPathIgnorePatterns are provided and file is a test file
+  :white_check_mark: when file is not in collectCoverageOnlyFrom when provided
+  :white_check_mark: when filename does not match collectCoverageFrom
+  :white_check_mark: if the file is in coveragePathIgnorePatterns
+  :white_check_mark: if file is in mock patterns
+  :white_check_mark: if file is a globalSetup file
+  :white_check_mark: if file is globalTeardown file
+  :white_check_mark: if file is in setupFiles
+  :white_check_mark: if file is in setupFilesAfterEnv
+```
+### :white_check_mark: <a id="user-content-r0s367" href="#r0s367">packages/jest-util/src/__tests__/createProcessObject.test.ts</a>
+```
+:white_check_mark: creates a process object that looks like the original one
+:white_check_mark: fakes require("process") so it is equal to "global.process"
+:white_check_mark: checks that process.env works as expected on Linux platforms
+:white_check_mark: checks that process.env works as expected in Windows platforms
+```
+### :white_check_mark: <a id="user-content-r0s368" href="#r0s368">packages/jest-util/src/__tests__/deepCyclicCopy.test.ts</a>
+```
+:white_check_mark: returns the same value for primitive or function values
+:white_check_mark: does not execute getters/setters, but copies them
+:white_check_mark: copies symbols
+:white_check_mark: copies arrays as array objects
+:white_check_mark: handles cyclic dependencies
+:white_check_mark: uses the blacklist to avoid copying properties on the first level
+:white_check_mark: does not keep the prototype by default when top level is object
+:white_check_mark: does not keep the prototype by default when top level is array
+:white_check_mark: does not keep the prototype of arrays when keepPrototype = false
+:white_check_mark: keeps the prototype of arrays when keepPrototype = true
+:white_check_mark: does not keep the prototype for objects when keepPrototype = false
+:white_check_mark: keeps the prototype for objects when keepPrototype = true
+```
+### :white_check_mark: <a id="user-content-r0s369" href="#r0s369">packages/jest-util/src/__tests__/errorWithStack.test.ts</a>
+```
+ErrorWithStack
+  :white_check_mark: calls Error.captureStackTrace with given callsite when capture exists
+```
+### :white_check_mark: <a id="user-content-r0s370" href="#r0s370">packages/jest-util/src/__tests__/formatTime.test.ts</a>
+```
+:white_check_mark: defaults to milliseconds
+:white_check_mark: formats seconds properly
+:white_check_mark: formats milliseconds properly
+:white_check_mark: formats microseconds properly
+:white_check_mark: formats nanoseconds properly
+:white_check_mark: interprets lower than lowest powers as nanoseconds
+:white_check_mark: interprets higher than highest powers as seconds
+:white_check_mark: interprets non-multiple-of-3 powers as next higher prefix
+:white_check_mark: formats the quantity properly when pad length is lower
+:white_check_mark: formats the quantity properly when pad length is equal
+:white_check_mark: left pads the quantity properly when pad length is higher
+```
+### :white_check_mark: <a id="user-content-r0s371" href="#r0s371">packages/jest-util/src/__tests__/globsToMatcher.test.ts</a>
+```
+:white_check_mark: works like micromatch with only positive globs
+:white_check_mark: works like micromatch with a mix of overlapping positive and negative globs
+:white_check_mark: works like micromatch with only negative globs
+:white_check_mark: works like micromatch with empty globs
+```
+### :white_check_mark: <a id="user-content-r0s372" href="#r0s372">packages/jest-util/src/__tests__/installCommonGlobals.test.ts</a>
+```
+:white_check_mark: returns the passed object
+:white_check_mark: turns a V8 global object into a Node global object
+```
+### :white_check_mark: <a id="user-content-r0s373" href="#r0s373">packages/jest-util/src/__tests__/isInteractive.test.ts</a>
+```
+:white_check_mark: Returns true when running on interactive environment
+:white_check_mark: Returns false when running on a non-interactive environment
+```
+### :white_check_mark: <a id="user-content-r0s374" href="#r0s374">packages/jest-util/src/__tests__/isPromise.test.ts</a>
+```
+not a Promise: 
+  :white_check_mark: undefined
+  :white_check_mark: null
+  :white_check_mark: true
+  :white_check_mark: 42
+  :white_check_mark: "1337"
+  :white_check_mark: Symbol()
+  :white_check_mark: []
+  :white_check_mark: {}
+:white_check_mark: a resolved Promise
+:white_check_mark: a rejected Promise
+```
+### :white_check_mark: <a id="user-content-r0s375" href="#r0s375">packages/jest-validate/src/__tests__/validate.test.ts</a>
+```
+:white_check_mark: recursively validates default Jest config
+:white_check_mark: recursively validates default jest-validate config
+:white_check_mark: pretty prints valid config for Boolean
+:white_check_mark: pretty prints valid config for Array
+:white_check_mark: pretty prints valid config for String
+:white_check_mark: pretty prints valid config for Object
+:white_check_mark: pretty prints valid config for Function
+:white_check_mark: omits null and undefined config values
+:white_check_mark: recursively omits null and undefined config values
+:white_check_mark: treat async and non-async functions as equivalent
+:white_check_mark: treat async and non-async functions as equivalent
+:white_check_mark: treat async and non-async functions as equivalent
+:white_check_mark: treat async and non-async functions as equivalent
+:white_check_mark: respects recursiveDenylist
+:white_check_mark: displays warning for unknown config options
+:white_check_mark: displays warning for deprecated config options
+:white_check_mark: works with custom warnings
+:white_check_mark: works with custom errors
+:white_check_mark: works with custom deprecations
+:white_check_mark: works with multiple valid types
+:white_check_mark: reports errors nicely when failing with multiple valid options
+:white_check_mark: Repeated types within multiple valid examples are coalesced in error report
+:white_check_mark: Comments in config JSON using "//" key are not warned
+```
+### :white_check_mark: <a id="user-content-r0s376" href="#r0s376">packages/jest-validate/src/__tests__/validateCLIOptions.test.js</a>
+```
+:white_check_mark: validates yargs special options
+:white_check_mark: validates testURL
+:white_check_mark: fails for unknown option
+:white_check_mark: fails for multiple unknown options
+:white_check_mark: does not show suggestion when unrecognized cli param length <= 1
+:white_check_mark: shows suggestion when unrecognized cli param length > 1
+```
+### :white_check_mark: <a id="user-content-r0s377" href="#r0s377">packages/jest-watcher/src/lib/__tests__/formatTestNameByPattern.test.ts</a>
+```
+for multiline test name returns
+  :white_check_mark: test name with highlighted pattern and replaced line breaks
+for one line test name with pattern in the head returns
+  :white_check_mark: test name with highlighted pattern
+  :white_check_mark: test name with cutted tail and highlighted pattern
+  :white_check_mark: test name with cutted tail and cutted highlighted pattern
+for one line test name pattern in the middle
+  :white_check_mark: test name with highlighted pattern returns
+  :white_check_mark: test name with cutted tail and highlighted pattern
+  :white_check_mark: test name with cutted tail and cutted highlighted pattern
+  :white_check_mark: test name with highlighted cutted
+for one line test name pattern in the tail returns
+  :white_check_mark: test name with highlighted pattern
+  :white_check_mark: test name with cutted tail and cutted highlighted pattern
+  :white_check_mark: test name with highlighted cutted
+```
+### :white_check_mark: <a id="user-content-r0s378" href="#r0s378">packages/jest-watcher/src/lib/__tests__/prompt.test.ts</a>
+```
+:white_check_mark: calls handler on change value
+:white_check_mark: calls handler on success prompt
+:white_check_mark: calls handler on cancel prompt
+```
+### :white_check_mark: <a id="user-content-r0s379" href="#r0s379">packages/jest-watcher/src/lib/__tests__/scroll.test.ts</a>
+```
+:white_check_mark: When offset is -1
+:white_check_mark: When offset is in the first set of items
+:white_check_mark: When offset is in the middle of the list
+:white_check_mark: When offset is at the end of the list
+:white_check_mark: When offset is at the end and size is smaller than max
+```
+### :white_check_mark: <a id="user-content-r0s380" href="#r0s380">packages/jest-worker/src/__tests__/Farm.test.js</a>
+```
+Farm
+  :white_check_mark: sends a request to one worker
+  :white_check_mark: sends four requests to four unique workers
+  :white_check_mark: handles null computeWorkerKey, sending to first worker
+  :white_check_mark: sends the same worker key to the same worker
+  :white_check_mark: returns the result if the call worked
+  :white_check_mark: throws if the call failed
+  :white_check_mark: checks that once a sticked task finishes, next time is sent to that worker
+  :white_check_mark: checks that even before a sticked task finishes, next time is sent to that worker
+  :white_check_mark: checks that locking works, and jobs are never lost
+  :white_check_mark: can receive custom messages from workers
+```
+### :white_check_mark: <a id="user-content-r0s381" href="#r0s381">packages/jest-worker/src/__tests__/FifoQueue.test.js</a>
+```
+:white_check_mark: returns the shared tasks in FIFO ordering
+:white_check_mark: returns the worker specific tasks in FIFO ordering
+:white_check_mark: maintains global FIFO ordering between worker specific and shared tasks
+```
+### :white_check_mark: <a id="user-content-r0s382" href="#r0s382">packages/jest-worker/src/__tests__/index.test.js</a>
+```
+:white_check_mark: exposes the right API using default working
+:white_check_mark: exposes the right API using passed worker
+:white_check_mark: breaks if any of the forbidden methods is tried to be exposed
+:white_check_mark: works with minimal options
+:white_check_mark: does not let make calls after the farm is ended
+:white_check_mark: does not let end the farm after it is ended
+:white_check_mark: calls doWork
+:white_check_mark: calls getStderr and getStdout from worker
+```
+### :white_check_mark: <a id="user-content-r0s383" href="#r0s383">packages/jest-worker/src/__tests__/PriorityQueue.test.js</a>
+```
+:white_check_mark: returns the tasks in order
+:white_check_mark: returns the task with the lowest priority value if inserted in reversed order
+:white_check_mark: returns the task with the lowest priority value if inserted in correct order
+:white_check_mark: uses different queues for each worker
+:white_check_mark: process task in the global and shared queue in order
+```
+### :white_check_mark: <a id="user-content-r0s384" href="#r0s384">packages/jest-worker/src/__tests__/process-integration.test.js</a>
+```
+Jest Worker Integration
+  :white_check_mark: calls a single method from the worker
+  :white_check_mark: distributes sequential calls across child processes
+  :white_check_mark: schedules the task on the first available child processes if the scheduling policy is in-order
+  :white_check_mark: distributes concurrent calls across child processes
+  :white_check_mark: sticks parallel calls to children
+```
+### :white_check_mark: <a id="user-content-r0s385" href="#r0s385">packages/jest-worker/src/__tests__/thread-integration.test.js</a>
+```
+Jest Worker Process Integration
+  :white_check_mark: calls a single method from the worker
+  :white_check_mark: distributes sequential calls across child processes
+  :white_check_mark: schedules the task on the first available child processes if the scheduling policy is in-order
+  :white_check_mark: schedules the task on the first available child processes
+  :white_check_mark: distributes concurrent calls across child processes
+  :white_check_mark: sticks parallel calls to children
+```
+### :white_check_mark: <a id="user-content-r0s386" href="#r0s386">packages/jest-worker/src/__tests__/WorkerPool.test.js</a>
+```
+WorkerPool
+  :white_check_mark: should create a ChildProcessWorker and send to it
+  :white_check_mark: should create a NodeThreadWorker and send to it
+  :white_check_mark: should avoid NodeThreadWorker if not passed enableWorkerThreads
+```
+### :white_check_mark: <a id="user-content-r0s387" href="#r0s387">packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js</a>
+```
+BaseWorkerPool
+  :white_check_mark: throws error when createWorker is not defined
+  :white_check_mark: creates and exposes n workers
+  :white_check_mark: creates and expoeses n workers
+  :white_check_mark: creates workers with the right options
+  :white_check_mark: makes a non-existing relative worker throw
+  :white_check_mark: create multiple workers with unique worker ids
+  :white_check_mark: aggregates all stdouts and stderrs from all workers
+  :white_check_mark: works when stdout and stderr are not piped to the parent
+BaseWorkerPool end
+  :white_check_mark: ends all workers
+  :white_check_mark: resolves with forceExited=false if workers exited gracefully
+  :white_check_mark: force exits workers that do not exit gracefully and resolves with forceExited=true
+```
+### :white_check_mark: <a id="user-content-r0s388" href="#r0s388">packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js</a>
+```
+:white_check_mark: passes fork options down to child_process.fork, adding the defaults
+:white_check_mark: passes workerId to the child process and assign it to 1-indexed env.JEST_WORKER_ID
+:white_check_mark: initializes the child process with the given workerPath
+:white_check_mark: stops initializing the worker after the amount of retries is exceeded
+:white_check_mark: provides stdout and stderr from the child processes
+:white_check_mark: sends the task to the child process
+:white_check_mark: resends the task to the child process after a retry
+:white_check_mark: calls the onProcessStart method synchronously if the queue is empty
+:white_check_mark: can send multiple messages to parent
+:white_check_mark: creates error instances for known errors
+:white_check_mark: throws when the child process returns a strange message
+:white_check_mark: does not restart the child if it cleanly exited
+:white_check_mark: resolves waitForExit() after the child process cleanly exited
+:white_check_mark: restarts the child when the child process dies
+:white_check_mark: sends SIGTERM when forceExit() is called
+:white_check_mark: sends SIGKILL some time after SIGTERM
+:white_check_mark: does not send SIGKILL if SIGTERM exited the process
+```
+### :white_check_mark: <a id="user-content-r0s389" href="#r0s389">packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js</a>
+```
+:white_check_mark: passes fork options down to child_process.fork, adding the defaults
+:white_check_mark: passes workerId to the thread and assign it to env.JEST_WORKER_ID
+:white_check_mark: initializes the thread with the given workerPath
+:white_check_mark: stops initializing the worker after the amount of retries is exceeded
+:white_check_mark: provides stdout and stderr from the threads
+:white_check_mark: sends the task to the thread
+:white_check_mark: resends the task to the thread after a retry
+:white_check_mark: calls the onProcessStart method synchronously if the queue is empty
+:white_check_mark: can send multiple messages to parent
+:white_check_mark: creates error instances for known errors
+:white_check_mark: throws when the thread returns a strange message
+:white_check_mark: does not restart the thread if it cleanly exited
+:white_check_mark: resolves waitForExit() after the thread cleanly exited
+:white_check_mark: restarts the thread when the thread dies
+:white_check_mark: terminates the thread when forceExit() is called
+```
+### :white_check_mark: <a id="user-content-r0s390" href="#r0s390">packages/jest-worker/src/workers/__tests__/processChild.test.js</a>
+```
+:white_check_mark: lazily requires the file
+:white_check_mark: calls initialize with the correct arguments
+:white_check_mark: returns results immediately when function is synchronous
+:white_check_mark: returns results when it gets resolved if function is asynchronous
+:white_check_mark: calls the main module if the method call is "default"
+:white_check_mark: calls the main export if the method call is "default" and it is a Babel transpiled one
+:white_check_mark: removes the message listener on END message
+:white_check_mark: calls the teardown method
+:white_check_mark: throws if an invalid message is detected
+:white_check_mark: throws if child is not forked
+```
+### :white_check_mark: <a id="user-content-r0s391" href="#r0s391">packages/jest-worker/src/workers/__tests__/threadChild.test.js</a>
+```
+:white_check_mark: lazily requires the file
+:white_check_mark: calls initialize with the correct arguments
+:white_check_mark: returns results immediately when function is synchronous
+:white_check_mark: returns results when it gets resolved if function is asynchronous
+:white_check_mark: calls the main module if the method call is "default"
+:white_check_mark: calls the main export if the method call is "default" and it is a Babel transpiled one
+:white_check_mark: removes the message listener on END message
+:white_check_mark: calls the teardown method
+:white_check_mark: throws if an invalid message is detected
+:white_check_mark: throws if child is not forked
+```
+### :white_check_mark: <a id="user-content-r0s392" href="#r0s392">packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts</a>
+```
+:white_check_mark: supports any(String)
+:white_check_mark: supports nested any(String)
+:white_check_mark: supports any(Function)
+:white_check_mark: supports nested any(Function)
+:white_check_mark: supports any(Array)
+:white_check_mark: supports nested any(Array)
+:white_check_mark: supports any(Object)
+:white_check_mark: supports nested any(Object)
+:white_check_mark: supports any(RegExp)
+:white_check_mark: supports nested any(RegExp)
+:white_check_mark: supports any(Symbol)
+:white_check_mark: supports nested any(Symbol)
+:white_check_mark: supports any(Function)
+:white_check_mark: supports nested any(Function)
+:white_check_mark: supports any(<anonymous>)
+:white_check_mark: supports nested any(<anonymous>)
+:white_check_mark: supports any(namedFuntction)
+:white_check_mark: supports nested any(namedFuntction)
+:white_check_mark: anything()
+:white_check_mark: arrayContaining()
+:white_check_mark: arrayNotContaining()
+:white_check_mark: objectContaining()
+:white_check_mark: objectNotContaining()
+:white_check_mark: stringContaining(string)
+:white_check_mark: not.stringContaining(string)
+:white_check_mark: stringMatching(string)
+:white_check_mark: stringMatching(regexp)
+:white_check_mark: stringMatching(regexp) {escapeRegex: false}
+:white_check_mark: stringMatching(regexp) {escapeRegex: true}
+:white_check_mark: stringNotMatching(string)
+:white_check_mark: supports multiple nested asymmetric matchers
+:white_check_mark: min option
+indent option
+  :white_check_mark: default implicit: 2 spaces
+  :white_check_mark: default explicit: 2 spaces
+  :white_check_mark: non-default: 0 spaces
+  :white_check_mark: non-default: 4 spaces
+maxDepth option
+  :white_check_mark: matchers as leaf nodes
+  :white_check_mark: matchers as internal nodes
+```
+### :white_check_mark: <a id="user-content-r0s393" href="#r0s393">packages/pretty-format/src/__tests__/ConvertAnsi.test.ts</a>
+```
+ConvertAnsi plugin
+  :white_check_mark: supports style.red
+  :white_check_mark: supports style.green
+  :white_check_mark: supports style.reset
+  :white_check_mark: supports style.bold
+  :white_check_mark: supports style.dim
+  :white_check_mark: does not support other colors
+```
+### :white_check_mark: <a id="user-content-r0s394" href="#r0s394">packages/pretty-format/src/__tests__/DOMCollection.test.ts</a>
+```
+DOMCollection plugin for object properties
+  :white_check_mark: supports DOMStringMap
+  :white_check_mark: supports NamedNodeMap
+  :white_check_mark: supports config.min option
+DOMCollection plugin for list items
+  :white_check_mark: supports HTMLCollection for getElementsByTagName
+  :white_check_mark: supports HTMLCollection for children
+  :white_check_mark: supports config.maxDepth option
+  :white_check_mark: supports NodeList for querySelectorAll
+  :white_check_mark: supports NodeList for childNodes
+  :white_check_mark: supports HTMLOptionsCollection for select options
+  :white_check_mark: supports HTMLCollection for form elements
+```
+### :white_check_mark: <a id="user-content-r0s395" href="#r0s395">packages/pretty-format/src/__tests__/DOMElement.test.ts</a>
+```
+pretty-format
+  :white_check_mark: prints global window as constructor name alone
+DOMElement Plugin
+  :white_check_mark: supports a single HTML element
+  :white_check_mark: supports an HTML element with a class property
+  :white_check_mark: supports an HTML element with a title property
+  :white_check_mark: escapes double quote in attribute value
+  :white_check_mark: supports an HTML element with a single attribute
+  :white_check_mark: supports an HTML element with multiple attributes
+  :white_check_mark: supports an HTML element with attribute and text content
+  :white_check_mark: supports an element with text content
+  :white_check_mark: supports nested elements
+  :white_check_mark: supports nested elements with attributes
+  :white_check_mark: supports nested elements with attribute and text content
+  :white_check_mark: supports nested elements with text content
+  :white_check_mark: supports siblings
+  :white_check_mark: supports multiline text node in pre
+  :white_check_mark: supports multiline text node preceding span in pre
+  :white_check_mark: supports multiline text node in textarea
+  :white_check_mark: supports empty text node
+  :white_check_mark: supports non-empty text node
+  :white_check_mark: supports comment node
+  :white_check_mark: supports fragment node
+  :white_check_mark: supports custom elements
+  :white_check_mark: supports SVG elements
+  :white_check_mark: supports indentation for array of elements
+  :white_check_mark: supports maxDepth option
+  :white_check_mark: handles `tagName` not being a string
+DOMElement Plugin matches constructor name of SVG elements
+  :white_check_mark: jsdom 9 and 10
+  :white_check_mark: jsdom 11
+```
+### :white_check_mark: <a id="user-content-r0s396" href="#r0s396">packages/pretty-format/src/__tests__/Immutable.test.ts</a>
+```
+:white_check_mark: does not incorrectly match identity-obj-proxy as Immutable object
+Immutable.OrderedSet
+  :white_check_mark: supports an empty collection {min: true}
+  :white_check_mark: supports an empty collection {min: false}
+  :white_check_mark: supports a single string element
+  :white_check_mark: supports a single integer element
+  :white_check_mark: supports multiple string elements {min: true}
+  :white_check_mark: supports multiple string elements {min: false}
+  :white_check_mark: supports multiple integer elements {min: true}
+  :white_check_mark: supports multiple integer elements {min: false}
+  :white_check_mark: supports object elements {min: true}
+  :white_check_mark: supports object elements {min: false}
+  :white_check_mark: supports React elements {min: true}
+  :white_check_mark: supports React elements {min: false}
+Immutable.List
+  :white_check_mark: supports an empty collection {min: true}
+  :white_check_mark: supports an empty collection {min: false}
+  :white_check_mark: supports a single string element
+  :white_check_mark: supports a single integer element
+  :white_check_mark: supports multiple string elements {min: true}
+  :white_check_mark: supports multiple string elements {min: false}
+  :white_check_mark: supports multiple integer elements {min: true}
+  :white_check_mark: supports multiple integer elements {min: false}
+  :white_check_mark: supports object elements {min: true}
+  :white_check_mark: supports object elements {min: false}
+  :white_check_mark: supports React elements {min: true}
+  :white_check_mark: supports React elements {min: false}
+Immutable.Stack
+  :white_check_mark: supports an empty collection {min: true}
+  :white_check_mark: supports an empty collection {min: false}
+  :white_check_mark: supports a single string element
+  :white_check_mark: supports a single integer element
+  :white_check_mark: supports multiple string elements {min: true}
+  :white_check_mark: supports multiple string elements {min: false}
+  :white_check_mark: supports multiple integer elements {min: true}
+  :white_check_mark: supports multiple integer elements {min: false}
+  :white_check_mark: supports object elements {min: true}
+  :white_check_mark: supports object elements {min: false}
+  :white_check_mark: supports React elements {min: true}
+  :white_check_mark: supports React elements {min: false}
+Immutable.Set
+  :white_check_mark: supports an empty collection {min: true}
+  :white_check_mark: supports an empty collection {min: false}
+  :white_check_mark: supports a single string element
+  :white_check_mark: supports a single integer element
+  :white_check_mark: supports multiple string elements {min: true}
+  :white_check_mark: supports multiple string elements {min: false}
+  :white_check_mark: supports multiple integer elements {min: true}
+  :white_check_mark: supports multiple integer elements {min: false}
+  :white_check_mark: supports object elements {min: true}
+  :white_check_mark: supports object elements {min: false}
+  :white_check_mark: supports React elements {min: true}
+  :white_check_mark: supports React elements {min: false}
+Immutable.Map
+  :white_check_mark: supports an empty collection {min: true}
+  :white_check_mark: supports an empty collection {min: false}
+  :white_check_mark: supports an object with single key
+  :white_check_mark: supports an object with multiple keys {min: true}
+  :white_check_mark: supports an object with multiple keys {min: false}
+  :white_check_mark: supports object elements {min: true}
+  :white_check_mark: supports object elements {min: false}
+  :white_check_mark: supports React elements {min: true}
+  :white_check_mark: supports React elements {min: false}
+Immutable.OrderedMap
+  :white_check_mark: supports an empty collection {min: true}
+  :white_check_mark: supports an empty collection {min: false}
+  :white_check_mark: supports an object with single key
+  :white_check_mark: supports an object with multiple keys {min: true}
+  :white_check_mark: supports an object with multiple keys {min: false}
+  :white_check_mark: supports object elements {min: true}
+  :white_check_mark: supports object elements {min: false}
+  :white_check_mark: supports React elements {min: true}
+  :white_check_mark: supports React elements {min: false}
+  :white_check_mark: supports non-string keys
+Immutable.Record
+  :white_check_mark: supports an empty record {min: true}
+  :white_check_mark: supports an empty record {min: false}
+  :white_check_mark: supports a record with descriptive name
+  :white_check_mark: supports a record without descriptive name
+  :white_check_mark: supports a record with values {min: true}
+  :white_check_mark: supports a record with values {min: false}
+  :white_check_mark: supports a record with Map value {min: true}
+  :white_check_mark: supports a record with Map value {min: false}
+  :white_check_mark: supports imbricated Record {min: true}
+  :white_check_mark: supports imbricated Record {min: false}
+indentation of heterogeneous collections
+  :white_check_mark: empty Immutable.List as child of Object
+  :white_check_mark: empty Immutable.Map as child of Array
+  :white_check_mark: non-empty Array as child of Immutable.Map
+  :white_check_mark: non-empty Object as child of Immutable.List
+indent option
+  :white_check_mark: default implicit: 2 spaces
+  :white_check_mark: default explicit: 2 spaces
+  :white_check_mark: non-default: 0 spaces
+  :white_check_mark: non-default: 4 spaces
+maxDepth option
+  :white_check_mark: Immutable.List as child of Object
+  :white_check_mark: Immutable.Map as child of Array
+  :white_check_mark: Immutable.Seq as child of Immutable.Map
+  :white_check_mark: Immutable.Map as descendants in immutable collection
+Immutable.Seq
+  :white_check_mark: supports an empty sequence from array {min: true}
+  :white_check_mark: supports an empty sequence from array {min: false}
+  :white_check_mark: supports a non-empty sequence from array {min: true}
+  :white_check_mark: supports a non-empty sequence from array {min: false}
+  :white_check_mark: supports a non-empty sequence from arguments
+  :white_check_mark: supports an empty sequence from object {min: true}
+  :white_check_mark: supports an empty sequence from object {min: false}
+  :white_check_mark: supports a non-empty sequence from object {min: true}
+  :white_check_mark: supports a non-empty sequence from object {min: false}
+  :white_check_mark: supports a sequence of entries from Immutable.Map
+  :white_check_mark: supports a sequence of values from ECMAScript Set
+  :white_check_mark: supports a sequence of values from Immutable.List
+  :white_check_mark: supports a sequence of values from Immutable.Set
+  :white_check_mark: supports a sequence of values from Immutable.Stack
+Immutable.Seq lazy entries
+  :white_check_mark: from object properties
+  :white_check_mark: from Immutable.Map entries
+Immutable.Seq lazy values
+  :white_check_mark: from Immutable.Range
+  :white_check_mark: from iterator
+  :white_check_mark: from array items
+  :white_check_mark: from Immutable.List values
+  :white_check_mark: from ECMAScript Set values
+```
+### :white_check_mark: <a id="user-content-r0s397" href="#r0s397">packages/pretty-format/src/__tests__/prettyFormat.test.ts</a>
+```
+prettyFormat()
+  :white_check_mark: prints empty arguments
+  :white_check_mark: prints arguments
+  :white_check_mark: prints an empty array
+  :white_check_mark: prints an array with items
+  :white_check_mark: prints a empty typed array
+  :white_check_mark: prints a typed array with items
+  :white_check_mark: prints an array buffer
+  :white_check_mark: prints a nested array
+  :white_check_mark: prints true
+  :white_check_mark: prints false
+  :white_check_mark: prints an error
+  :white_check_mark: prints a typed error with a message
+  :white_check_mark: prints a function constructor
+  :white_check_mark: prints an anonymous callback function
+  :white_check_mark: prints an anonymous assigned function
+  :white_check_mark: prints a named function
+  :white_check_mark: prints a named generator function
+  :white_check_mark: can customize function names
+  :white_check_mark: prints Infinity
+  :white_check_mark: prints -Infinity
+  :white_check_mark: prints an empty map
+  :white_check_mark: prints a map with values
+  :white_check_mark: prints a map with non-string keys
+  :white_check_mark: prints NaN
+  :white_check_mark: prints null
+  :white_check_mark: prints a positive number
+  :white_check_mark: prints a negative number
+  :white_check_mark: prints zero
+  :white_check_mark: prints negative zero
+  :white_check_mark: prints a positive bigint
+  :white_check_mark: prints a negative bigint
+  :white_check_mark: prints zero bigint
+  :white_check_mark: prints negative zero bigint
+  :white_check_mark: prints a date
+  :white_check_mark: prints an invalid date
+  :white_check_mark: prints an empty object
+  :white_check_mark: prints an object with properties
+  :white_check_mark: prints an object with properties and symbols
+  :white_check_mark: prints an object without non-enumerable properties which have string key
+  :white_check_mark: prints an object without non-enumerable properties which have symbol key
+  :white_check_mark: prints an object with sorted properties
+  :white_check_mark: prints regular expressions from constructors
+  :white_check_mark: prints regular expressions from literals
+  :white_check_mark: prints regular expressions {escapeRegex: false}
+  :white_check_mark: prints regular expressions {escapeRegex: true}
+  :white_check_mark: escapes regular expressions nested inside object
+  :white_check_mark: prints an empty set
+  :white_check_mark: prints a set with values
+  :white_check_mark: prints a string
+  :white_check_mark: prints and escape a string
+  :white_check_mark: doesn't escape string with {excapeString: false}
+  :white_check_mark: prints a string with escapes
+  :white_check_mark: prints a multiline string
+  :white_check_mark: prints a multiline string as value of object property
+  :white_check_mark: prints a symbol
+  :white_check_mark: prints undefined
+  :white_check_mark: prints a WeakMap
+  :white_check_mark: prints a WeakSet
+  :white_check_mark: prints deeply nested objects
+  :white_check_mark: prints circular references
+  :white_check_mark: prints parallel references
+  :white_check_mark: can customize the max depth
+  :white_check_mark: throws on invalid options
+  :white_check_mark: supports plugins
+  :white_check_mark: supports plugins that return empty string
+  :white_check_mark: throws if plugin does not return a string
+  :white_check_mark: throws PrettyFormatPluginError if test throws an error
+  :white_check_mark: throws PrettyFormatPluginError if print throws an error
+  :white_check_mark: throws PrettyFormatPluginError if serialize throws an error
+  :white_check_mark: supports plugins with deeply nested arrays (#24)
+  :white_check_mark: should call plugins on nested basic values
+  :white_check_mark: prints objects with no constructor
+  :white_check_mark: prints identity-obj-proxy with string constructor
+  :white_check_mark: calls toJSON and prints its return value
+  :white_check_mark: calls toJSON and prints an internal representation.
+  :white_check_mark: calls toJSON only on functions
+  :white_check_mark: does not call toJSON recursively
+  :white_check_mark: calls toJSON on Sets
+  :white_check_mark: disables toJSON calls through options
+prettyFormat() indent option
+  :white_check_mark: default implicit: 2 spaces
+  :white_check_mark: default explicit: 2 spaces
+  :white_check_mark: non-default: 0 spaces
+  :white_check_mark: non-default: 4 spaces
+prettyFormat() min
+  :white_check_mark: prints some basic values in min mode
+  :white_check_mark: prints some complex values in min mode
+  :white_check_mark: does not allow indent !== 0 in min mode
+```
+### :white_check_mark: <a id="user-content-r0s398" href="#r0s398">packages/pretty-format/src/__tests__/react.test.tsx</a>
+```
+:white_check_mark: supports a single element with no props or children
+:white_check_mark: supports a single element with non-empty string child
+:white_check_mark: supports a single element with empty string child
+:white_check_mark: supports a single element with non-zero number child
+:white_check_mark: supports a single element with zero number child
+:white_check_mark: supports a single element with mixed children
+:white_check_mark: supports props with strings
+:white_check_mark: supports props with multiline strings
+:white_check_mark: supports props with numbers
+:white_check_mark: supports a single element with a function prop
+:white_check_mark: supports a single element with a object prop
+:white_check_mark: supports an element with and object prop and children
+:white_check_mark: supports an element with complex props and mixed children
+:white_check_mark: escapes children properly
+:white_check_mark: supports everything all together
+:white_check_mark: sorts props in nested components
+:white_check_mark: supports a single element with React elements as props
+:white_check_mark: supports a single element with React elements with props
+:white_check_mark: supports a single element with custom React elements with props
+:white_check_mark: supports a single element with custom React elements with props (using displayName)
+:white_check_mark: supports a single element with custom React elements with props (using anonymous function)
+:white_check_mark: supports a single element with custom React elements with a child
+:white_check_mark: supports undefined element type
+:white_check_mark: supports a fragment with no children
+:white_check_mark: supports a fragment with string child
+:white_check_mark: supports a fragment with element child
+:white_check_mark: supports suspense
+:white_check_mark: supports a single element with React elements with a child
+:white_check_mark: supports a single element with React elements with children
+:white_check_mark: supports a single element with React elements with array children
+:white_check_mark: supports array of elements
+:white_check_mark: min option
+:white_check_mark: ReactElement plugin highlights syntax
+:white_check_mark: ReactTestComponent plugin highlights syntax
+:white_check_mark: throws if theme option is null
+:white_check_mark: throws if theme option is not of type "object"
+:white_check_mark: throws if theme option has value that is undefined in ansi-styles
+:white_check_mark: ReactElement plugin highlights syntax with color from theme option
+:white_check_mark: ReactTestComponent plugin highlights syntax with color from theme option
+:white_check_mark: supports forwardRef with a child
+:white_check_mark: supports context Provider with a child
+:white_check_mark: supports context Consumer with a child
+:white_check_mark: ReactElement removes undefined props
+:white_check_mark: ReactTestComponent removes undefined props
+test object for subset match
+  :white_check_mark: undefined props
+  :white_check_mark: undefined children
+indent option
+  :white_check_mark: default implicit: 2 spaces
+  :white_check_mark: default explicit: 2 spaces
+  :white_check_mark: non-default: 0 spaces
+  :white_check_mark: non-default: 4 spaces
+maxDepth option
+  :white_check_mark: elements
+  :white_check_mark: array of elements
+React.memo without displayName
+  :white_check_mark: renders the component name
+React.memo with displayName
+  :white_check_mark: renders the displayName of component before memoizing
+  :white_check_mark: renders the displayName of memoized component
+```
+### :white_check_mark: <a id="user-content-r0s399" href="#r0s399">packages/pretty-format/src/__tests__/ReactElement.test.ts</a>
+```
+ReactElement Plugin
+  :white_check_mark: serializes forwardRef without displayName
+  :white_check_mark: serializes forwardRef with displayName
+  :white_check_mark: serializes forwardRef component with displayName
 ```

--- a/__tests__/__outputs__/mocha-json.md
+++ b/__tests__/__outputs__/mocha-json.md
@@ -1,13 +1,13 @@
 ![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/mocha-json.json|1:white_check_mark:|4:x:|1:warning:|12ms|
+|fixtures/mocha-json.json|1 :white_check_mark:|4 :x:|1 :warning:|12ms|
 ## :x: <a id="user-content-r0" href="#r0">fixtures/mocha-json.json</a>
 **6** tests were completed in **12ms** with **1** passed, **4** failed and **1** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[test/main.test.js](#r0s0)|1:white_check_mark:|3:x:||1ms|
-|[test/second.test.js](#r0s1)||1:x:|1:warning:|8ms|
+|[test/main.test.js](#r0s0)|1 :white_check_mark:|3 :x:||1ms|
+|[test/second.test.js](#r0s1)||1 :x:|1 :warning:|8ms|
 ### :x: <a id="user-content-r0s0" href="#r0s0">test/main.test.js</a>
 ```
 Test 1

--- a/__tests__/__outputs__/mocha-test-results.md
+++ b/__tests__/__outputs__/mocha-test-results.md
@@ -3,47 +3,47 @@
  
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/external/mocha/mocha-test-results.json|833:white_check_mark:||6:warning:|6s|
+|fixtures/external/mocha/mocha-test-results.json|833 :white_check_mark:||6 :warning:|6s|
 ## :white_check_mark: <a id="user-content-r0" href="#r0">fixtures/external/mocha/mocha-test-results.json</a>
 **839** tests were completed in **6s** with **833** passed, **0** failed and **6** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[test/node-unit/buffered-worker-pool.spec.js](#r0s0)|14:white_check_mark:|||8ms|
-|[test/node-unit/cli/config.spec.js](#r0s1)|10:white_check_mark:|||8ms|
-|[test/node-unit/cli/node-flags.spec.js](#r0s2)|105:white_check_mark:|||9ms|
-|[test/node-unit/cli/options.spec.js](#r0s3)|36:white_check_mark:|||250ms|
-|[test/node-unit/cli/run-helpers.spec.js](#r0s4)|9:white_check_mark:|||8ms|
-|[test/node-unit/cli/run.spec.js](#r0s5)|40:white_check_mark:|||4ms|
-|[test/node-unit/mocha.spec.js](#r0s6)|24:white_check_mark:|||33ms|
-|[test/node-unit/parallel-buffered-runner.spec.js](#r0s7)|19:white_check_mark:|||23ms|
-|[test/node-unit/reporters/parallel-buffered.spec.js](#r0s8)|6:white_check_mark:|||16ms|
-|[test/node-unit/serializer.spec.js](#r0s9)|40:white_check_mark:|||31ms|
-|[test/node-unit/stack-trace-filter.spec.js](#r0s10)|2:white_check_mark:||4:warning:|1ms|
-|[test/node-unit/utils.spec.js](#r0s11)|5:white_check_mark:|||1ms|
-|[test/node-unit/worker.spec.js](#r0s12)|15:white_check_mark:|||92ms|
-|[test/unit/context.spec.js](#r0s13)|8:white_check_mark:|||5ms|
-|[test/unit/duration.spec.js](#r0s14)|3:white_check_mark:|||166ms|
-|[test/unit/errors.spec.js](#r0s15)|13:white_check_mark:|||5ms|
-|[test/unit/globals.spec.js](#r0s16)|4:white_check_mark:|||0ms|
-|[test/unit/grep.spec.js](#r0s17)|8:white_check_mark:|||2ms|
-|[test/unit/hook-async.spec.js](#r0s18)|3:white_check_mark:|||1ms|
-|[test/unit/hook-sync-nested.spec.js](#r0s19)|4:white_check_mark:|||1ms|
-|[test/unit/hook-sync.spec.js](#r0s20)|3:white_check_mark:|||0ms|
-|[test/unit/hook-timeout.spec.js](#r0s21)|1:white_check_mark:|||0ms|
-|[test/unit/hook.spec.js](#r0s22)|4:white_check_mark:|||0ms|
-|[test/unit/mocha.spec.js](#r0s23)|115:white_check_mark:||1:warning:|128ms|
-|[test/unit/overspecified-async.spec.js](#r0s24)|1:white_check_mark:|||3ms|
-|[test/unit/parse-query.spec.js](#r0s25)|2:white_check_mark:|||1ms|
-|[test/unit/plugin-loader.spec.js](#r0s26)|41:white_check_mark:||1:warning:|16ms|
-|[test/unit/required-tokens.spec.js](#r0s27)|1:white_check_mark:|||0ms|
-|[test/unit/root.spec.js](#r0s28)|1:white_check_mark:|||0ms|
-|[test/unit/runnable.spec.js](#r0s29)|55:white_check_mark:|||122ms|
-|[test/unit/runner.spec.js](#r0s30)|77:white_check_mark:|||43ms|
-|[test/unit/suite.spec.js](#r0s31)|57:white_check_mark:|||14ms|
-|[test/unit/test.spec.js](#r0s32)|15:white_check_mark:|||0ms|
-|[test/unit/throw.spec.js](#r0s33)|9:white_check_mark:|||9ms|
-|[test/unit/timeout.spec.js](#r0s34)|8:white_check_mark:|||109ms|
-|[test/unit/utils.spec.js](#r0s35)|75:white_check_mark:|||24ms|
+|[test/node-unit/buffered-worker-pool.spec.js](#r0s0)|14 :white_check_mark:|||8ms|
+|[test/node-unit/cli/config.spec.js](#r0s1)|10 :white_check_mark:|||8ms|
+|[test/node-unit/cli/node-flags.spec.js](#r0s2)|105 :white_check_mark:|||9ms|
+|[test/node-unit/cli/options.spec.js](#r0s3)|36 :white_check_mark:|||250ms|
+|[test/node-unit/cli/run-helpers.spec.js](#r0s4)|9 :white_check_mark:|||8ms|
+|[test/node-unit/cli/run.spec.js](#r0s5)|40 :white_check_mark:|||4ms|
+|[test/node-unit/mocha.spec.js](#r0s6)|24 :white_check_mark:|||33ms|
+|[test/node-unit/parallel-buffered-runner.spec.js](#r0s7)|19 :white_check_mark:|||23ms|
+|[test/node-unit/reporters/parallel-buffered.spec.js](#r0s8)|6 :white_check_mark:|||16ms|
+|[test/node-unit/serializer.spec.js](#r0s9)|40 :white_check_mark:|||31ms|
+|[test/node-unit/stack-trace-filter.spec.js](#r0s10)|2 :white_check_mark:||4 :warning:|1ms|
+|[test/node-unit/utils.spec.js](#r0s11)|5 :white_check_mark:|||1ms|
+|[test/node-unit/worker.spec.js](#r0s12)|15 :white_check_mark:|||92ms|
+|[test/unit/context.spec.js](#r0s13)|8 :white_check_mark:|||5ms|
+|[test/unit/duration.spec.js](#r0s14)|3 :white_check_mark:|||166ms|
+|[test/unit/errors.spec.js](#r0s15)|13 :white_check_mark:|||5ms|
+|[test/unit/globals.spec.js](#r0s16)|4 :white_check_mark:|||0ms|
+|[test/unit/grep.spec.js](#r0s17)|8 :white_check_mark:|||2ms|
+|[test/unit/hook-async.spec.js](#r0s18)|3 :white_check_mark:|||1ms|
+|[test/unit/hook-sync-nested.spec.js](#r0s19)|4 :white_check_mark:|||1ms|
+|[test/unit/hook-sync.spec.js](#r0s20)|3 :white_check_mark:|||0ms|
+|[test/unit/hook-timeout.spec.js](#r0s21)|1 :white_check_mark:|||0ms|
+|[test/unit/hook.spec.js](#r0s22)|4 :white_check_mark:|||0ms|
+|[test/unit/mocha.spec.js](#r0s23)|115 :white_check_mark:||1 :warning:|128ms|
+|[test/unit/overspecified-async.spec.js](#r0s24)|1 :white_check_mark:|||3ms|
+|[test/unit/parse-query.spec.js](#r0s25)|2 :white_check_mark:|||1ms|
+|[test/unit/plugin-loader.spec.js](#r0s26)|41 :white_check_mark:||1 :warning:|16ms|
+|[test/unit/required-tokens.spec.js](#r0s27)|1 :white_check_mark:|||0ms|
+|[test/unit/root.spec.js](#r0s28)|1 :white_check_mark:|||0ms|
+|[test/unit/runnable.spec.js](#r0s29)|55 :white_check_mark:|||122ms|
+|[test/unit/runner.spec.js](#r0s30)|77 :white_check_mark:|||43ms|
+|[test/unit/suite.spec.js](#r0s31)|57 :white_check_mark:|||14ms|
+|[test/unit/test.spec.js](#r0s32)|15 :white_check_mark:|||0ms|
+|[test/unit/throw.spec.js](#r0s33)|9 :white_check_mark:|||9ms|
+|[test/unit/timeout.spec.js](#r0s34)|8 :white_check_mark:|||109ms|
+|[test/unit/utils.spec.js](#r0s35)|75 :white_check_mark:|||24ms|
 ### :white_check_mark: <a id="user-content-r0s0" href="#r0s0">test/node-unit/buffered-worker-pool.spec.js</a>
 ```
 class BufferedWorkerPool constructor

--- a/__tests__/__outputs__/provider-test-results.md
+++ b/__tests__/__outputs__/provider-test-results.md
@@ -1,27 +1,27 @@
 ![Tests failed](https://img.shields.io/badge/tests-268%20passed%2C%201%20failed-critical)
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/external/flutter/provider-test-results.json|268:white_check_mark:|1:x:||0ms|
+|fixtures/external/flutter/provider-test-results.json|268 :white_check_mark:|1 :x:||0ms|
 ## :x: <a id="user-content-r0" href="#r0">fixtures/external/flutter/provider-test-results.json</a>
 **269** tests were completed in **0ms** with **268** passed, **1** failed and **0** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[test/builder_test.dart](#r0s0)|24:white_check_mark:|||402ms|
-|[test/change_notifier_provider_test.dart](#r0s1)|10:white_check_mark:|||306ms|
-|[test/consumer_test.dart](#r0s2)|18:white_check_mark:|||340ms|
-|[test/context_test.dart](#r0s3)|31:white_check_mark:|||698ms|
-|[test/future_provider_test.dart](#r0s4)|10:white_check_mark:|||305ms|
-|[test/inherited_provider_test.dart](#r0s5)|81:white_check_mark:|||1s|
-|[test/listenable_provider_test.dart](#r0s6)|16:white_check_mark:|||353ms|
-|[test/listenable_proxy_provider_test.dart](#r0s7)|12:white_check_mark:|||373ms|
-|[test/multi_provider_test.dart](#r0s8)|3:white_check_mark:|||198ms|
-|[test/provider_test.dart](#r0s9)|11:white_check_mark:|||306ms|
-|[test/proxy_provider_test.dart](#r0s10)|16:white_check_mark:|||438ms|
-|[test/reassemble_test.dart](#r0s11)|3:white_check_mark:|||221ms|
-|[test/selector_test.dart](#r0s12)|17:white_check_mark:|||364ms|
-|[test/stateful_provider_test.dart](#r0s13)|4:white_check_mark:|||254ms|
-|[test/stream_provider_test.dart](#r0s14)|8:white_check_mark:|||282ms|
-|[test/value_listenable_provider_test.dart](#r0s15)|4:white_check_mark:|1:x:||327ms|
+|[test/builder_test.dart](#r0s0)|24 :white_check_mark:|||402ms|
+|[test/change_notifier_provider_test.dart](#r0s1)|10 :white_check_mark:|||306ms|
+|[test/consumer_test.dart](#r0s2)|18 :white_check_mark:|||340ms|
+|[test/context_test.dart](#r0s3)|31 :white_check_mark:|||698ms|
+|[test/future_provider_test.dart](#r0s4)|10 :white_check_mark:|||305ms|
+|[test/inherited_provider_test.dart](#r0s5)|81 :white_check_mark:|||1s|
+|[test/listenable_provider_test.dart](#r0s6)|16 :white_check_mark:|||353ms|
+|[test/listenable_proxy_provider_test.dart](#r0s7)|12 :white_check_mark:|||373ms|
+|[test/multi_provider_test.dart](#r0s8)|3 :white_check_mark:|||198ms|
+|[test/provider_test.dart](#r0s9)|11 :white_check_mark:|||306ms|
+|[test/proxy_provider_test.dart](#r0s10)|16 :white_check_mark:|||438ms|
+|[test/reassemble_test.dart](#r0s11)|3 :white_check_mark:|||221ms|
+|[test/selector_test.dart](#r0s12)|17 :white_check_mark:|||364ms|
+|[test/stateful_provider_test.dart](#r0s13)|4 :white_check_mark:|||254ms|
+|[test/stream_provider_test.dart](#r0s14)|8 :white_check_mark:|||282ms|
+|[test/value_listenable_provider_test.dart](#r0s15)|4 :white_check_mark:|1 :x:||327ms|
 ### :white_check_mark: <a id="user-content-r0s0" href="#r0s0">test/builder_test.dart</a>
 ```
 ChangeNotifierProvider

--- a/__tests__/__outputs__/pulsar-test-results-no-merge.md
+++ b/__tests__/__outputs__/pulsar-test-results-no-merge.md
@@ -1,12 +1,12 @@
 ![Tests failed](https://img.shields.io/badge/tests-1%20failed%2C%201%20skipped-critical)
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/external/java/TEST-org.apache.pulsar.AddMissingPatchVersionTest.xml||1:x:|1:warning:|116ms|
+|fixtures/external/java/TEST-org.apache.pulsar.AddMissingPatchVersionTest.xml||1 :x:|1 :warning:|116ms|
 ## :x: <a id="user-content-r0" href="#r0">fixtures/external/java/TEST-org.apache.pulsar.AddMissingPatchVersionTest.xml</a>
 **2** tests were completed in **116ms** with **0** passed, **1** failed and **1** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[org.apache.pulsar.AddMissingPatchVersionTest](#r0s0)||1:x:|1:warning:|116ms|
+|[org.apache.pulsar.AddMissingPatchVersionTest](#r0s0)||1 :x:|1 :warning:|116ms|
 ### :x: <a id="user-content-r0s0" href="#r0s0">org.apache.pulsar.AddMissingPatchVersionTest</a>
 ```
 :warning: testVersionStrings

--- a/__tests__/__outputs__/pulsar-test-results.md
+++ b/__tests__/__outputs__/pulsar-test-results.md
@@ -1,187 +1,187 @@
 ![Tests failed](https://img.shields.io/badge/tests-793%20passed%2C%201%20failed%2C%2014%20skipped-critical)
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/external/java/pulsar-test-report.xml|793:white_check_mark:|1:x:|14:warning:|2127s|
+|fixtures/external/java/pulsar-test-report.xml|793 :white_check_mark:|1 :x:|14 :warning:|2127s|
 ## :x: <a id="user-content-r0" href="#r0">fixtures/external/java/pulsar-test-report.xml</a>
 **808** tests were completed in **2127s** with **793** passed, **1** failed and **14** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[org.apache.pulsar.AddMissingPatchVersionTest](#r0s0)||1:x:|1:warning:|116ms|
-|[org.apache.pulsar.broker.admin.AdminApiOffloadTest](#r0s1)|7:white_check_mark:|||19s|
-|[org.apache.pulsar.broker.auth.AuthenticationServiceTest](#r0s2)|2:white_check_mark:|||185ms|
-|[org.apache.pulsar.broker.auth.AuthLogsTest](#r0s3)|2:white_check_mark:|||1s|
-|[org.apache.pulsar.broker.auth.AuthorizationTest](#r0s4)|1:white_check_mark:|||2s|
-|[org.apache.pulsar.broker.lookup.http.HttpTopicLookupv2Test](#r0s5)|4:white_check_mark:|||2s|
-|[org.apache.pulsar.broker.namespace.NamespaceCreateBundlesTest](#r0s6)|2:white_check_mark:|||33s|
-|[org.apache.pulsar.broker.namespace.NamespaceOwnershipListenerTests](#r0s7)|2:white_check_mark:|||32s|
-|[org.apache.pulsar.broker.namespace.NamespaceServiceTest](#r0s8)|10:white_check_mark:|||75s|
-|[org.apache.pulsar.broker.namespace.NamespaceUnloadingTest](#r0s9)|2:white_check_mark:|||14s|
-|[org.apache.pulsar.broker.namespace.OwnerShipCacheForCurrentServerTest](#r0s10)|1:white_check_mark:|||16s|
-|[org.apache.pulsar.broker.namespace.OwnershipCacheTest](#r0s11)|8:white_check_mark:|||16s|
-|[org.apache.pulsar.broker.protocol.ProtocolHandlersTest](#r0s12)|6:white_check_mark:|||946ms|
-|[org.apache.pulsar.broker.protocol.ProtocolHandlerUtilsTest](#r0s13)|3:white_check_mark:|||7s|
-|[org.apache.pulsar.broker.protocol.ProtocolHandlerWithClassLoaderTest](#r0s14)|1:white_check_mark:|||15ms|
-|[org.apache.pulsar.broker.PulsarServiceTest](#r0s15)|2:white_check_mark:|||96ms|
-|[org.apache.pulsar.broker.service.MessagePublishBufferThrottleTest](#r0s16)|3:white_check_mark:|||14s|
-|[org.apache.pulsar.broker.service.ReplicatorTest](#r0s17)|22:white_check_mark:|||40s|
-|[org.apache.pulsar.broker.service.TopicOwnerTest](#r0s18)|8:white_check_mark:|||114s|
-|[org.apache.pulsar.broker.SLAMonitoringTest](#r0s19)|4:white_check_mark:|||9s|
-|[org.apache.pulsar.broker.stats.BookieClientsStatsGeneratorTest](#r0s20)|2:white_check_mark:|||49ms|
-|[org.apache.pulsar.broker.stats.ConsumerStatsTest](#r0s21)|3:white_check_mark:|||21s|
-|[org.apache.pulsar.broker.stats.ManagedCursorMetricsTest](#r0s22)|1:white_check_mark:|||281ms|
-|[org.apache.pulsar.broker.stats.ManagedLedgerMetricsTest](#r0s23)|1:white_check_mark:|||285ms|
-|[org.apache.pulsar.broker.stats.prometheus.AggregatedNamespaceStatsTest](#r0s24)|1:white_check_mark:|||40ms|
-|[org.apache.pulsar.broker.stats.PrometheusMetricsTest](#r0s25)|15:white_check_mark:|||83s|
-|[org.apache.pulsar.broker.stats.SubscriptionStatsTest](#r0s26)|2:white_check_mark:|||2s|
-|[org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicServiceTest](#r0s27)|1:white_check_mark:|||1s|
-|[org.apache.pulsar.broker.transaction.buffer.InMemTransactionBufferReaderTest](#r0s28)|3:white_check_mark:|||28ms|
-|[org.apache.pulsar.broker.transaction.buffer.TransactionBufferClientTest](#r0s29)|4:white_check_mark:|||93ms|
-|[org.apache.pulsar.broker.transaction.buffer.TransactionBufferTest](#r0s30)|7:white_check_mark:|||81ms|
-|[org.apache.pulsar.broker.transaction.buffer.TransactionEntryImplTest](#r0s31)|1:white_check_mark:|||14ms|
-|[org.apache.pulsar.broker.transaction.buffer.TransactionLowWaterMarkTest](#r0s32)|2:white_check_mark:|||38s|
-|[org.apache.pulsar.broker.transaction.buffer.TransactionStablePositionTest](#r0s33)|2:white_check_mark:||1:warning:|49s|
-|[org.apache.pulsar.broker.transaction.coordinator.TransactionCoordinatorClientTest](#r0s34)|3:white_check_mark:|||95ms|
-|[org.apache.pulsar.broker.transaction.coordinator.TransactionMetaStoreAssignmentTest](#r0s35)|1:white_check_mark:|||1s|
-|[org.apache.pulsar.broker.transaction.pendingack.PendingAckInMemoryDeleteTest](#r0s36)|2:white_check_mark:||1:warning:|57s|
-|[org.apache.pulsar.broker.transaction.TransactionConsumeTest](#r0s37)|2:white_check_mark:|||30s|
-|[org.apache.pulsar.broker.web.RestExceptionTest](#r0s38)|3:white_check_mark:|||37ms|
-|[org.apache.pulsar.broker.web.WebServiceTest](#r0s39)|9:white_check_mark:|||27s|
-|[org.apache.pulsar.client.impl.AdminApiKeyStoreTlsAuthTest](#r0s40)|4:white_check_mark:|||8s|
-|[org.apache.pulsar.client.impl.BatchMessageIdImplSerializationTest](#r0s41)|4:white_check_mark:|||30ms|
-|[org.apache.pulsar.client.impl.BatchMessageIndexAckDisableTest](#r0s42)|4:white_check_mark:|||14s|
-|[org.apache.pulsar.client.impl.BatchMessageIndexAckTest](#r0s43)|5:white_check_mark:|||44s|
-|[org.apache.pulsar.client.impl.BrokerClientIntegrationTest](#r0s44)|15:white_check_mark:|||148s|
-|[org.apache.pulsar.client.impl.CompactedOutBatchMessageTest](#r0s45)|1:white_check_mark:|||1s|
-|[org.apache.pulsar.client.impl.ConsumerAckResponseTest](#r0s46)|1:white_check_mark:|||549ms|
-|[org.apache.pulsar.client.impl.ConsumerConfigurationTest](#r0s47)|4:white_check_mark:|||12s|
-|[org.apache.pulsar.client.impl.ConsumerDedupPermitsUpdate](#r0s48)|7:white_check_mark:|||4s|
-|[org.apache.pulsar.client.impl.ConsumerUnsubscribeTest](#r0s49)|1:white_check_mark:|||129ms|
-|[org.apache.pulsar.client.impl.KeyStoreTlsProducerConsumerTestWithAuth](#r0s50)|3:white_check_mark:|||23s|
-|[org.apache.pulsar.client.impl.KeyStoreTlsProducerConsumerTestWithoutAuth](#r0s51)|3:white_check_mark:|||8s|
-|[org.apache.pulsar.client.impl.KeyStoreTlsTest](#r0s52)|1:white_check_mark:|||183ms|
-|[org.apache.pulsar.client.impl.MessageChecksumTest](#r0s53)|3:white_check_mark:|||47s|
-|[org.apache.pulsar.client.impl.MessageChunkingTest](#r0s54)|8:white_check_mark:||1:warning:|73s|
-|[org.apache.pulsar.client.impl.MessageParserTest](#r0s55)|2:white_check_mark:|||5s|
-|[org.apache.pulsar.client.impl.MultiTopicsReaderTest](#r0s56)|8:white_check_mark:|||35s|
-|[org.apache.pulsar.client.impl.NegativeAcksTest](#r0s57)|32:white_check_mark:|||11s|
-|[org.apache.pulsar.client.impl.PatternTopicsConsumerImplTest](#r0s58)|11:white_check_mark:|||63s|
-|[org.apache.pulsar.client.impl.PerMessageUnAcknowledgedRedeliveryTest](#r0s59)|5:white_check_mark:|||34s|
-|[org.apache.pulsar.client.impl.PulsarMultiHostClientTest](#r0s60)|3:white_check_mark:|||15s|
-|[org.apache.pulsar.client.impl.RawMessageSerDeserTest](#r0s61)|1:white_check_mark:|||10ms|
-|[org.apache.pulsar.client.impl.SchemaDeleteTest](#r0s62)|1:white_check_mark:|||2s|
-|[org.apache.pulsar.client.impl.SequenceIdWithErrorTest](#r0s63)|3:white_check_mark:||2:warning:|18s|
-|[org.apache.pulsar.client.impl.TopicDoesNotExistsTest](#r0s64)|2:white_check_mark:|||4s|
-|[org.apache.pulsar.client.impl.TopicFromMessageTest](#r0s65)|5:white_check_mark:|||14s|
-|[org.apache.pulsar.client.impl.TopicsConsumerImplTest](#r0s66)|17:white_check_mark:|||133s|
-|[org.apache.pulsar.client.impl.UnAcknowledgedMessagesTimeoutTest](#r0s67)|7:white_check_mark:|||44s|
-|[org.apache.pulsar.client.impl.ZeroQueueSizeTest](#r0s68)|14:white_check_mark:|||16s|
-|[org.apache.pulsar.common.api.raw.RawMessageImplTest](#r0s69)|1:white_check_mark:|||316ms|
-|[org.apache.pulsar.common.compression.CommandsTest](#r0s70)|1:white_check_mark:|||30ms|
-|[org.apache.pulsar.common.compression.CompressorCodecBackwardCompatTest](#r0s71)|6:white_check_mark:|||223ms|
-|[org.apache.pulsar.common.compression.CompressorCodecTest](#r0s72)|45:white_check_mark:|||737ms|
-|[org.apache.pulsar.common.compression.Crc32cChecksumTest](#r0s73)|6:white_check_mark:|||5s|
-|[org.apache.pulsar.common.lookup.data.LookupDataTest](#r0s74)|4:white_check_mark:|||2s|
-|[org.apache.pulsar.common.naming.MetadataTests](#r0s75)|2:white_check_mark:|||161ms|
-|[org.apache.pulsar.common.naming.NamespaceBundlesTest](#r0s76)|5:white_check_mark:|||99ms|
-|[org.apache.pulsar.common.naming.NamespaceBundleTest](#r0s77)|6:white_check_mark:|||64ms|
-|[org.apache.pulsar.common.naming.NamespaceNameTest](#r0s78)|2:white_check_mark:|||207ms|
-|[org.apache.pulsar.common.naming.ServiceConfigurationTest](#r0s79)|4:white_check_mark:|||48ms|
-|[org.apache.pulsar.common.naming.TopicNameTest](#r0s80)|4:white_check_mark:|||529ms|
-|[org.apache.pulsar.common.net.ServiceURITest](#r0s81)|21:white_check_mark:|||237ms|
-|[org.apache.pulsar.common.policies.data.AutoFailoverPolicyDataTest](#r0s82)|1:white_check_mark:|||15ms|
-|[org.apache.pulsar.common.policies.data.AutoFailoverPolicyTypeTest](#r0s83)|1:white_check_mark:|||19ms|
-|[org.apache.pulsar.common.policies.data.AutoTopicCreationOverrideTest](#r0s84)|6:white_check_mark:|||64ms|
-|[org.apache.pulsar.common.policies.data.BacklogQuotaTest](#r0s85)|1:white_check_mark:|||12ms|
-|[org.apache.pulsar.common.policies.data.ClusterDataTest](#r0s86)|1:white_check_mark:|||9ms|
-|[org.apache.pulsar.common.policies.data.ConsumerStatsTest](#r0s87)|1:white_check_mark:|||8ms|
-|[org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfigTest](#r0s88)|2:white_check_mark:|||948ms|
-|[org.apache.pulsar.common.policies.data.LocalPolicesTest](#r0s89)|1:white_check_mark:|||48ms|
-|[org.apache.pulsar.common.policies.data.NamespaceIsolationDataTest](#r0s90)|1:white_check_mark:|||76ms|
-|[org.apache.pulsar.common.policies.data.NamespaceOwnershipStatusTest](#r0s91)|1:white_check_mark:|||45ms|
-|[org.apache.pulsar.common.policies.data.OffloadPoliciesTest](#r0s92)|6:white_check_mark:|||216ms|
-|[org.apache.pulsar.common.policies.data.PartitionedTopicStatsTest](#r0s93)|1:white_check_mark:|||12ms|
-|[org.apache.pulsar.common.policies.data.PersistencePoliciesTest](#r0s94)|1:white_check_mark:|||19ms|
-|[org.apache.pulsar.common.policies.data.PersistentOfflineTopicStatsTest](#r0s95)|1:white_check_mark:|||29ms|
-|[org.apache.pulsar.common.policies.data.PersistentTopicStatsTest](#r0s96)|2:white_check_mark:|||51ms|
-|[org.apache.pulsar.common.policies.data.PoliciesDataTest](#r0s97)|4:white_check_mark:|||1s|
-|[org.apache.pulsar.common.policies.data.PublisherStatsTest](#r0s98)|2:white_check_mark:|||37ms|
-|[org.apache.pulsar.common.policies.data.ReplicatorStatsTest](#r0s99)|2:white_check_mark:|||30ms|
-|[org.apache.pulsar.common.policies.data.ResourceQuotaTest](#r0s100)|2:white_check_mark:|||45ms|
-|[org.apache.pulsar.common.policies.data.RetentionPolicesTest](#r0s101)|1:white_check_mark:|||8ms|
-|[org.apache.pulsar.common.policies.impl.AutoFailoverPolicyFactoryTest](#r0s102)|1:white_check_mark:|||22ms|
-|[org.apache.pulsar.common.policies.impl.MinAvailablePolicyTest](#r0s103)|1:white_check_mark:|||1ms|
-|[org.apache.pulsar.common.policies.impl.NamespaceIsolationPoliciesTest](#r0s104)|7:white_check_mark:|||265ms|
-|[org.apache.pulsar.common.policies.impl.NamespaceIsolationPolicyImplTest](#r0s105)|7:white_check_mark:|||309ms|
-|[org.apache.pulsar.common.protocol.ByteBufPairTest](#r0s106)|2:white_check_mark:|||5s|
-|[org.apache.pulsar.common.protocol.CommandUtilsTests](#r0s107)|7:white_check_mark:|||3s|
-|[org.apache.pulsar.common.protocol.MarkersTest](#r0s108)|6:white_check_mark:|||3s|
-|[org.apache.pulsar.common.protocol.PulsarDecoderTest](#r0s109)|1:white_check_mark:|||4s|
-|[org.apache.pulsar.common.stats.JvmDefaultGCMetricsLoggerTest](#r0s110)|1:white_check_mark:|||82ms|
-|[org.apache.pulsar.common.util.collections.BitSetRecyclableRecyclableTest](#r0s111)|2:white_check_mark:|||13ms|
-|[org.apache.pulsar.common.util.collections.ConcurrentBitSetRecyclableTest](#r0s112)|2:white_check_mark:|||63ms|
-|[org.apache.pulsar.common.util.collections.ConcurrentLongHashMapTest](#r0s113)|13:white_check_mark:|||28s|
-|[org.apache.pulsar.common.util.collections.ConcurrentLongPairSetTest](#r0s114)|15:white_check_mark:|||2s|
-|[org.apache.pulsar.common.util.collections.ConcurrentOpenHashMapTest](#r0s115)|12:white_check_mark:|||9s|
-|[org.apache.pulsar.common.util.collections.ConcurrentOpenHashSetTest](#r0s116)|11:white_check_mark:|||7s|
-|[org.apache.pulsar.common.util.collections.ConcurrentOpenLongPairRangeSetTest](#r0s117)|13:white_check_mark:|||1s|
-|[org.apache.pulsar.common.util.collections.ConcurrentSortedLongPairSetTest](#r0s118)|9:white_check_mark:|||342ms|
-|[org.apache.pulsar.common.util.collections.FieldParserTest](#r0s119)|2:white_check_mark:|||64ms|
-|[org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueueTest](#r0s120)|6:white_check_mark:|||350ms|
-|[org.apache.pulsar.common.util.collections.GrowablePriorityLongPairQueueTest](#r0s121)|15:white_check_mark:|||3s|
-|[org.apache.pulsar.common.util.collections.TripleLongPriorityQueueTest](#r0s122)|3:white_check_mark:|||238ms|
-|[org.apache.pulsar.common.util.FieldParserTest](#r0s123)|1:white_check_mark:|||242ms|
-|[org.apache.pulsar.common.util.FileModifiedTimeUpdaterTest](#r0s124)|6:white_check_mark:|||6s|
-|[org.apache.pulsar.common.util.netty.ChannelFuturesTest](#r0s125)|5:white_check_mark:|||2s|
-|[org.apache.pulsar.common.util.RateLimiterTest](#r0s126)|11:white_check_mark:|||7s|
-|[org.apache.pulsar.common.util.ReflectionsTest](#r0s127)|12:white_check_mark:|||172ms|
-|[org.apache.pulsar.common.util.RelativeTimeUtilTest](#r0s128)|1:white_check_mark:|||39ms|
-|[org.apache.pulsar.discovery.service.web.DiscoveryServiceWebTest](#r0s129)|1:white_check_mark:|||5s|
-|[org.apache.pulsar.functions.worker.PulsarFunctionE2ESecurityTest](#r0s130)|2:white_check_mark:|||28s|
-|[org.apache.pulsar.functions.worker.PulsarFunctionPublishTest](#r0s131)|3:white_check_mark:|||42s|
-|[org.apache.pulsar.functions.worker.PulsarFunctionTlsTest](#r0s132)|1:white_check_mark:|||12s|
-|[org.apache.pulsar.io.PulsarFunctionTlsTest](#r0s133)|1:white_check_mark:|||30s|
-|[org.apache.pulsar.proxy.server.AdminProxyHandlerTest](#r0s134)|1:white_check_mark:|||474ms|
-|[org.apache.pulsar.proxy.server.AuthedAdminProxyHandlerTest](#r0s135)|1:white_check_mark:|||2s|
-|[org.apache.pulsar.proxy.server.FunctionWorkerRoutingTest](#r0s136)|1:white_check_mark:|||10ms|
-|[org.apache.pulsar.proxy.server.ProxyAdditionalServletTest](#r0s137)|1:white_check_mark:|||125ms|
-|[org.apache.pulsar.proxy.server.ProxyAuthenticatedProducerConsumerTest](#r0s138)|1:white_check_mark:|||2s|
-|[org.apache.pulsar.proxy.server.ProxyAuthenticationTest](#r0s139)|1:white_check_mark:|||17s|
-|[org.apache.pulsar.proxy.server.ProxyConnectionThrottlingTest](#r0s140)|1:white_check_mark:|||2s|
-|[org.apache.pulsar.proxy.server.ProxyEnableHAProxyProtocolTest](#r0s141)|1:white_check_mark:|||511ms|
-|[org.apache.pulsar.proxy.server.ProxyForwardAuthDataTest](#r0s142)|1:white_check_mark:|||32s|
-|[org.apache.pulsar.proxy.server.ProxyIsAHttpProxyTest](#r0s143)|10:white_check_mark:|||2s|
-|[org.apache.pulsar.proxy.server.ProxyKeyStoreTlsTestWithAuth](#r0s144)|3:white_check_mark:|||7s|
-|[org.apache.pulsar.proxy.server.ProxyKeyStoreTlsTestWithoutAuth](#r0s145)|3:white_check_mark:|||7s|
-|[org.apache.pulsar.proxy.server.ProxyLookupThrottlingTest](#r0s146)|1:white_check_mark:|||3s|
-|[org.apache.pulsar.proxy.server.ProxyParserTest](#r0s147)|5:white_check_mark:|||1s|
-|[org.apache.pulsar.proxy.server.ProxyRolesEnforcementTest](#r0s148)|1:white_check_mark:|||10s|
-|[org.apache.pulsar.proxy.server.ProxyStatsTest](#r0s149)|3:white_check_mark:|||533ms|
-|[org.apache.pulsar.proxy.server.ProxyTest](#r0s150)|6:white_check_mark:|||3s|
-|[org.apache.pulsar.proxy.server.ProxyTlsTest](#r0s151)|2:white_check_mark:|||414ms|
-|[org.apache.pulsar.proxy.server.ProxyTlsTestWithAuth](#r0s152)|1:white_check_mark:|||4ms|
-|[org.apache.pulsar.proxy.server.ProxyWithAuthorizationNegTest](#r0s153)|1:white_check_mark:|||2s|
-|[org.apache.pulsar.proxy.server.ProxyWithAuthorizationTest](#r0s154)|13:white_check_mark:|||33s|
-|[org.apache.pulsar.proxy.server.ProxyWithoutServiceDiscoveryTest](#r0s155)|1:white_check_mark:|||2s|
-|[org.apache.pulsar.proxy.server.SuperUserAuthedAdminProxyHandlerTest](#r0s156)|3:white_check_mark:|||8s|
-|[org.apache.pulsar.proxy.server.UnauthedAdminProxyHandlerTest](#r0s157)|2:white_check_mark:|||114ms|
-|[org.apache.pulsar.PulsarBrokerStarterTest](#r0s158)|9:white_check_mark:|||591ms|
-|[org.apache.pulsar.schema.compatibility.SchemaCompatibilityCheckTest](#r0s159)|23:white_check_mark:|||107s|
-|[org.apache.pulsar.schema.PartitionedTopicSchemaTest](#r0s160)|1:white_check_mark:|||29s|
-|[org.apache.pulsar.schema.SchemaTest](#r0s161)|3:white_check_mark:|||31s|
-|[org.apache.pulsar.stats.client.PulsarBrokerStatsClientTest](#r0s162)|2:white_check_mark:|||41s|
-|[org.apache.pulsar.tests.EnumValuesDataProviderTest](#r0s163)|6:white_check_mark:|||23ms|
-|[org.apache.pulsar.tests.TestRetrySupportBeforeMethodRetryTest](#r0s164)|1:white_check_mark:||4:warning:|36ms|
-|[org.apache.pulsar.tests.TestRetrySupportRetryTest](#r0s165)|1:white_check_mark:||4:warning:|27ms|
-|[org.apache.pulsar.tests.TestRetrySupportSuccessTest](#r0s166)|3:white_check_mark:|||1ms|
-|[org.apache.pulsar.tests.ThreadDumpUtilTest](#r0s167)|2:white_check_mark:|||17ms|
-|[org.apache.pulsar.utils.SimpleTextOutputStreamTest](#r0s168)|4:white_check_mark:|||50ms|
-|[org.apache.pulsar.utils.StatsOutputStreamTest](#r0s169)|6:white_check_mark:|||59ms|
-|[org.apache.pulsar.websocket.proxy.ProxyAuthenticationTest](#r0s170)|4:white_check_mark:|||29s|
-|[org.apache.pulsar.websocket.proxy.ProxyAuthorizationTest](#r0s171)|1:white_check_mark:|||1s|
-|[org.apache.pulsar.websocket.proxy.ProxyConfigurationTest](#r0s172)|2:white_check_mark:|||9s|
-|[org.apache.pulsar.websocket.proxy.ProxyPublishConsumeTlsTest](#r0s173)|1:white_check_mark:|||11s|
-|[org.apache.pulsar.websocket.proxy.ProxyPublishConsumeWithoutZKTest](#r0s174)|1:white_check_mark:|||7s|
-|[org.apache.pulsar.websocket.proxy.v1.V1_ProxyAuthenticationTest](#r0s175)|4:white_check_mark:|||30s|
+|[org.apache.pulsar.AddMissingPatchVersionTest](#r0s0)||1 :x:|1 :warning:|116ms|
+|[org.apache.pulsar.broker.admin.AdminApiOffloadTest](#r0s1)|7 :white_check_mark:|||19s|
+|[org.apache.pulsar.broker.auth.AuthenticationServiceTest](#r0s2)|2 :white_check_mark:|||185ms|
+|[org.apache.pulsar.broker.auth.AuthLogsTest](#r0s3)|2 :white_check_mark:|||1s|
+|[org.apache.pulsar.broker.auth.AuthorizationTest](#r0s4)|1 :white_check_mark:|||2s|
+|[org.apache.pulsar.broker.lookup.http.HttpTopicLookupv2Test](#r0s5)|4 :white_check_mark:|||2s|
+|[org.apache.pulsar.broker.namespace.NamespaceCreateBundlesTest](#r0s6)|2 :white_check_mark:|||33s|
+|[org.apache.pulsar.broker.namespace.NamespaceOwnershipListenerTests](#r0s7)|2 :white_check_mark:|||32s|
+|[org.apache.pulsar.broker.namespace.NamespaceServiceTest](#r0s8)|10 :white_check_mark:|||75s|
+|[org.apache.pulsar.broker.namespace.NamespaceUnloadingTest](#r0s9)|2 :white_check_mark:|||14s|
+|[org.apache.pulsar.broker.namespace.OwnerShipCacheForCurrentServerTest](#r0s10)|1 :white_check_mark:|||16s|
+|[org.apache.pulsar.broker.namespace.OwnershipCacheTest](#r0s11)|8 :white_check_mark:|||16s|
+|[org.apache.pulsar.broker.protocol.ProtocolHandlersTest](#r0s12)|6 :white_check_mark:|||946ms|
+|[org.apache.pulsar.broker.protocol.ProtocolHandlerUtilsTest](#r0s13)|3 :white_check_mark:|||7s|
+|[org.apache.pulsar.broker.protocol.ProtocolHandlerWithClassLoaderTest](#r0s14)|1 :white_check_mark:|||15ms|
+|[org.apache.pulsar.broker.PulsarServiceTest](#r0s15)|2 :white_check_mark:|||96ms|
+|[org.apache.pulsar.broker.service.MessagePublishBufferThrottleTest](#r0s16)|3 :white_check_mark:|||14s|
+|[org.apache.pulsar.broker.service.ReplicatorTest](#r0s17)|22 :white_check_mark:|||40s|
+|[org.apache.pulsar.broker.service.TopicOwnerTest](#r0s18)|8 :white_check_mark:|||114s|
+|[org.apache.pulsar.broker.SLAMonitoringTest](#r0s19)|4 :white_check_mark:|||9s|
+|[org.apache.pulsar.broker.stats.BookieClientsStatsGeneratorTest](#r0s20)|2 :white_check_mark:|||49ms|
+|[org.apache.pulsar.broker.stats.ConsumerStatsTest](#r0s21)|3 :white_check_mark:|||21s|
+|[org.apache.pulsar.broker.stats.ManagedCursorMetricsTest](#r0s22)|1 :white_check_mark:|||281ms|
+|[org.apache.pulsar.broker.stats.ManagedLedgerMetricsTest](#r0s23)|1 :white_check_mark:|||285ms|
+|[org.apache.pulsar.broker.stats.prometheus.AggregatedNamespaceStatsTest](#r0s24)|1 :white_check_mark:|||40ms|
+|[org.apache.pulsar.broker.stats.PrometheusMetricsTest](#r0s25)|15 :white_check_mark:|||83s|
+|[org.apache.pulsar.broker.stats.SubscriptionStatsTest](#r0s26)|2 :white_check_mark:|||2s|
+|[org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicServiceTest](#r0s27)|1 :white_check_mark:|||1s|
+|[org.apache.pulsar.broker.transaction.buffer.InMemTransactionBufferReaderTest](#r0s28)|3 :white_check_mark:|||28ms|
+|[org.apache.pulsar.broker.transaction.buffer.TransactionBufferClientTest](#r0s29)|4 :white_check_mark:|||93ms|
+|[org.apache.pulsar.broker.transaction.buffer.TransactionBufferTest](#r0s30)|7 :white_check_mark:|||81ms|
+|[org.apache.pulsar.broker.transaction.buffer.TransactionEntryImplTest](#r0s31)|1 :white_check_mark:|||14ms|
+|[org.apache.pulsar.broker.transaction.buffer.TransactionLowWaterMarkTest](#r0s32)|2 :white_check_mark:|||38s|
+|[org.apache.pulsar.broker.transaction.buffer.TransactionStablePositionTest](#r0s33)|2 :white_check_mark:||1 :warning:|49s|
+|[org.apache.pulsar.broker.transaction.coordinator.TransactionCoordinatorClientTest](#r0s34)|3 :white_check_mark:|||95ms|
+|[org.apache.pulsar.broker.transaction.coordinator.TransactionMetaStoreAssignmentTest](#r0s35)|1 :white_check_mark:|||1s|
+|[org.apache.pulsar.broker.transaction.pendingack.PendingAckInMemoryDeleteTest](#r0s36)|2 :white_check_mark:||1 :warning:|57s|
+|[org.apache.pulsar.broker.transaction.TransactionConsumeTest](#r0s37)|2 :white_check_mark:|||30s|
+|[org.apache.pulsar.broker.web.RestExceptionTest](#r0s38)|3 :white_check_mark:|||37ms|
+|[org.apache.pulsar.broker.web.WebServiceTest](#r0s39)|9 :white_check_mark:|||27s|
+|[org.apache.pulsar.client.impl.AdminApiKeyStoreTlsAuthTest](#r0s40)|4 :white_check_mark:|||8s|
+|[org.apache.pulsar.client.impl.BatchMessageIdImplSerializationTest](#r0s41)|4 :white_check_mark:|||30ms|
+|[org.apache.pulsar.client.impl.BatchMessageIndexAckDisableTest](#r0s42)|4 :white_check_mark:|||14s|
+|[org.apache.pulsar.client.impl.BatchMessageIndexAckTest](#r0s43)|5 :white_check_mark:|||44s|
+|[org.apache.pulsar.client.impl.BrokerClientIntegrationTest](#r0s44)|15 :white_check_mark:|||148s|
+|[org.apache.pulsar.client.impl.CompactedOutBatchMessageTest](#r0s45)|1 :white_check_mark:|||1s|
+|[org.apache.pulsar.client.impl.ConsumerAckResponseTest](#r0s46)|1 :white_check_mark:|||549ms|
+|[org.apache.pulsar.client.impl.ConsumerConfigurationTest](#r0s47)|4 :white_check_mark:|||12s|
+|[org.apache.pulsar.client.impl.ConsumerDedupPermitsUpdate](#r0s48)|7 :white_check_mark:|||4s|
+|[org.apache.pulsar.client.impl.ConsumerUnsubscribeTest](#r0s49)|1 :white_check_mark:|||129ms|
+|[org.apache.pulsar.client.impl.KeyStoreTlsProducerConsumerTestWithAuth](#r0s50)|3 :white_check_mark:|||23s|
+|[org.apache.pulsar.client.impl.KeyStoreTlsProducerConsumerTestWithoutAuth](#r0s51)|3 :white_check_mark:|||8s|
+|[org.apache.pulsar.client.impl.KeyStoreTlsTest](#r0s52)|1 :white_check_mark:|||183ms|
+|[org.apache.pulsar.client.impl.MessageChecksumTest](#r0s53)|3 :white_check_mark:|||47s|
+|[org.apache.pulsar.client.impl.MessageChunkingTest](#r0s54)|8 :white_check_mark:||1 :warning:|73s|
+|[org.apache.pulsar.client.impl.MessageParserTest](#r0s55)|2 :white_check_mark:|||5s|
+|[org.apache.pulsar.client.impl.MultiTopicsReaderTest](#r0s56)|8 :white_check_mark:|||35s|
+|[org.apache.pulsar.client.impl.NegativeAcksTest](#r0s57)|32 :white_check_mark:|||11s|
+|[org.apache.pulsar.client.impl.PatternTopicsConsumerImplTest](#r0s58)|11 :white_check_mark:|||63s|
+|[org.apache.pulsar.client.impl.PerMessageUnAcknowledgedRedeliveryTest](#r0s59)|5 :white_check_mark:|||34s|
+|[org.apache.pulsar.client.impl.PulsarMultiHostClientTest](#r0s60)|3 :white_check_mark:|||15s|
+|[org.apache.pulsar.client.impl.RawMessageSerDeserTest](#r0s61)|1 :white_check_mark:|||10ms|
+|[org.apache.pulsar.client.impl.SchemaDeleteTest](#r0s62)|1 :white_check_mark:|||2s|
+|[org.apache.pulsar.client.impl.SequenceIdWithErrorTest](#r0s63)|3 :white_check_mark:||2 :warning:|18s|
+|[org.apache.pulsar.client.impl.TopicDoesNotExistsTest](#r0s64)|2 :white_check_mark:|||4s|
+|[org.apache.pulsar.client.impl.TopicFromMessageTest](#r0s65)|5 :white_check_mark:|||14s|
+|[org.apache.pulsar.client.impl.TopicsConsumerImplTest](#r0s66)|17 :white_check_mark:|||133s|
+|[org.apache.pulsar.client.impl.UnAcknowledgedMessagesTimeoutTest](#r0s67)|7 :white_check_mark:|||44s|
+|[org.apache.pulsar.client.impl.ZeroQueueSizeTest](#r0s68)|14 :white_check_mark:|||16s|
+|[org.apache.pulsar.common.api.raw.RawMessageImplTest](#r0s69)|1 :white_check_mark:|||316ms|
+|[org.apache.pulsar.common.compression.CommandsTest](#r0s70)|1 :white_check_mark:|||30ms|
+|[org.apache.pulsar.common.compression.CompressorCodecBackwardCompatTest](#r0s71)|6 :white_check_mark:|||223ms|
+|[org.apache.pulsar.common.compression.CompressorCodecTest](#r0s72)|45 :white_check_mark:|||737ms|
+|[org.apache.pulsar.common.compression.Crc32cChecksumTest](#r0s73)|6 :white_check_mark:|||5s|
+|[org.apache.pulsar.common.lookup.data.LookupDataTest](#r0s74)|4 :white_check_mark:|||2s|
+|[org.apache.pulsar.common.naming.MetadataTests](#r0s75)|2 :white_check_mark:|||161ms|
+|[org.apache.pulsar.common.naming.NamespaceBundlesTest](#r0s76)|5 :white_check_mark:|||99ms|
+|[org.apache.pulsar.common.naming.NamespaceBundleTest](#r0s77)|6 :white_check_mark:|||64ms|
+|[org.apache.pulsar.common.naming.NamespaceNameTest](#r0s78)|2 :white_check_mark:|||207ms|
+|[org.apache.pulsar.common.naming.ServiceConfigurationTest](#r0s79)|4 :white_check_mark:|||48ms|
+|[org.apache.pulsar.common.naming.TopicNameTest](#r0s80)|4 :white_check_mark:|||529ms|
+|[org.apache.pulsar.common.net.ServiceURITest](#r0s81)|21 :white_check_mark:|||237ms|
+|[org.apache.pulsar.common.policies.data.AutoFailoverPolicyDataTest](#r0s82)|1 :white_check_mark:|||15ms|
+|[org.apache.pulsar.common.policies.data.AutoFailoverPolicyTypeTest](#r0s83)|1 :white_check_mark:|||19ms|
+|[org.apache.pulsar.common.policies.data.AutoTopicCreationOverrideTest](#r0s84)|6 :white_check_mark:|||64ms|
+|[org.apache.pulsar.common.policies.data.BacklogQuotaTest](#r0s85)|1 :white_check_mark:|||12ms|
+|[org.apache.pulsar.common.policies.data.ClusterDataTest](#r0s86)|1 :white_check_mark:|||9ms|
+|[org.apache.pulsar.common.policies.data.ConsumerStatsTest](#r0s87)|1 :white_check_mark:|||8ms|
+|[org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfigTest](#r0s88)|2 :white_check_mark:|||948ms|
+|[org.apache.pulsar.common.policies.data.LocalPolicesTest](#r0s89)|1 :white_check_mark:|||48ms|
+|[org.apache.pulsar.common.policies.data.NamespaceIsolationDataTest](#r0s90)|1 :white_check_mark:|||76ms|
+|[org.apache.pulsar.common.policies.data.NamespaceOwnershipStatusTest](#r0s91)|1 :white_check_mark:|||45ms|
+|[org.apache.pulsar.common.policies.data.OffloadPoliciesTest](#r0s92)|6 :white_check_mark:|||216ms|
+|[org.apache.pulsar.common.policies.data.PartitionedTopicStatsTest](#r0s93)|1 :white_check_mark:|||12ms|
+|[org.apache.pulsar.common.policies.data.PersistencePoliciesTest](#r0s94)|1 :white_check_mark:|||19ms|
+|[org.apache.pulsar.common.policies.data.PersistentOfflineTopicStatsTest](#r0s95)|1 :white_check_mark:|||29ms|
+|[org.apache.pulsar.common.policies.data.PersistentTopicStatsTest](#r0s96)|2 :white_check_mark:|||51ms|
+|[org.apache.pulsar.common.policies.data.PoliciesDataTest](#r0s97)|4 :white_check_mark:|||1s|
+|[org.apache.pulsar.common.policies.data.PublisherStatsTest](#r0s98)|2 :white_check_mark:|||37ms|
+|[org.apache.pulsar.common.policies.data.ReplicatorStatsTest](#r0s99)|2 :white_check_mark:|||30ms|
+|[org.apache.pulsar.common.policies.data.ResourceQuotaTest](#r0s100)|2 :white_check_mark:|||45ms|
+|[org.apache.pulsar.common.policies.data.RetentionPolicesTest](#r0s101)|1 :white_check_mark:|||8ms|
+|[org.apache.pulsar.common.policies.impl.AutoFailoverPolicyFactoryTest](#r0s102)|1 :white_check_mark:|||22ms|
+|[org.apache.pulsar.common.policies.impl.MinAvailablePolicyTest](#r0s103)|1 :white_check_mark:|||1ms|
+|[org.apache.pulsar.common.policies.impl.NamespaceIsolationPoliciesTest](#r0s104)|7 :white_check_mark:|||265ms|
+|[org.apache.pulsar.common.policies.impl.NamespaceIsolationPolicyImplTest](#r0s105)|7 :white_check_mark:|||309ms|
+|[org.apache.pulsar.common.protocol.ByteBufPairTest](#r0s106)|2 :white_check_mark:|||5s|
+|[org.apache.pulsar.common.protocol.CommandUtilsTests](#r0s107)|7 :white_check_mark:|||3s|
+|[org.apache.pulsar.common.protocol.MarkersTest](#r0s108)|6 :white_check_mark:|||3s|
+|[org.apache.pulsar.common.protocol.PulsarDecoderTest](#r0s109)|1 :white_check_mark:|||4s|
+|[org.apache.pulsar.common.stats.JvmDefaultGCMetricsLoggerTest](#r0s110)|1 :white_check_mark:|||82ms|
+|[org.apache.pulsar.common.util.collections.BitSetRecyclableRecyclableTest](#r0s111)|2 :white_check_mark:|||13ms|
+|[org.apache.pulsar.common.util.collections.ConcurrentBitSetRecyclableTest](#r0s112)|2 :white_check_mark:|||63ms|
+|[org.apache.pulsar.common.util.collections.ConcurrentLongHashMapTest](#r0s113)|13 :white_check_mark:|||28s|
+|[org.apache.pulsar.common.util.collections.ConcurrentLongPairSetTest](#r0s114)|15 :white_check_mark:|||2s|
+|[org.apache.pulsar.common.util.collections.ConcurrentOpenHashMapTest](#r0s115)|12 :white_check_mark:|||9s|
+|[org.apache.pulsar.common.util.collections.ConcurrentOpenHashSetTest](#r0s116)|11 :white_check_mark:|||7s|
+|[org.apache.pulsar.common.util.collections.ConcurrentOpenLongPairRangeSetTest](#r0s117)|13 :white_check_mark:|||1s|
+|[org.apache.pulsar.common.util.collections.ConcurrentSortedLongPairSetTest](#r0s118)|9 :white_check_mark:|||342ms|
+|[org.apache.pulsar.common.util.collections.FieldParserTest](#r0s119)|2 :white_check_mark:|||64ms|
+|[org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueueTest](#r0s120)|6 :white_check_mark:|||350ms|
+|[org.apache.pulsar.common.util.collections.GrowablePriorityLongPairQueueTest](#r0s121)|15 :white_check_mark:|||3s|
+|[org.apache.pulsar.common.util.collections.TripleLongPriorityQueueTest](#r0s122)|3 :white_check_mark:|||238ms|
+|[org.apache.pulsar.common.util.FieldParserTest](#r0s123)|1 :white_check_mark:|||242ms|
+|[org.apache.pulsar.common.util.FileModifiedTimeUpdaterTest](#r0s124)|6 :white_check_mark:|||6s|
+|[org.apache.pulsar.common.util.netty.ChannelFuturesTest](#r0s125)|5 :white_check_mark:|||2s|
+|[org.apache.pulsar.common.util.RateLimiterTest](#r0s126)|11 :white_check_mark:|||7s|
+|[org.apache.pulsar.common.util.ReflectionsTest](#r0s127)|12 :white_check_mark:|||172ms|
+|[org.apache.pulsar.common.util.RelativeTimeUtilTest](#r0s128)|1 :white_check_mark:|||39ms|
+|[org.apache.pulsar.discovery.service.web.DiscoveryServiceWebTest](#r0s129)|1 :white_check_mark:|||5s|
+|[org.apache.pulsar.functions.worker.PulsarFunctionE2ESecurityTest](#r0s130)|2 :white_check_mark:|||28s|
+|[org.apache.pulsar.functions.worker.PulsarFunctionPublishTest](#r0s131)|3 :white_check_mark:|||42s|
+|[org.apache.pulsar.functions.worker.PulsarFunctionTlsTest](#r0s132)|1 :white_check_mark:|||12s|
+|[org.apache.pulsar.io.PulsarFunctionTlsTest](#r0s133)|1 :white_check_mark:|||30s|
+|[org.apache.pulsar.proxy.server.AdminProxyHandlerTest](#r0s134)|1 :white_check_mark:|||474ms|
+|[org.apache.pulsar.proxy.server.AuthedAdminProxyHandlerTest](#r0s135)|1 :white_check_mark:|||2s|
+|[org.apache.pulsar.proxy.server.FunctionWorkerRoutingTest](#r0s136)|1 :white_check_mark:|||10ms|
+|[org.apache.pulsar.proxy.server.ProxyAdditionalServletTest](#r0s137)|1 :white_check_mark:|||125ms|
+|[org.apache.pulsar.proxy.server.ProxyAuthenticatedProducerConsumerTest](#r0s138)|1 :white_check_mark:|||2s|
+|[org.apache.pulsar.proxy.server.ProxyAuthenticationTest](#r0s139)|1 :white_check_mark:|||17s|
+|[org.apache.pulsar.proxy.server.ProxyConnectionThrottlingTest](#r0s140)|1 :white_check_mark:|||2s|
+|[org.apache.pulsar.proxy.server.ProxyEnableHAProxyProtocolTest](#r0s141)|1 :white_check_mark:|||511ms|
+|[org.apache.pulsar.proxy.server.ProxyForwardAuthDataTest](#r0s142)|1 :white_check_mark:|||32s|
+|[org.apache.pulsar.proxy.server.ProxyIsAHttpProxyTest](#r0s143)|10 :white_check_mark:|||2s|
+|[org.apache.pulsar.proxy.server.ProxyKeyStoreTlsTestWithAuth](#r0s144)|3 :white_check_mark:|||7s|
+|[org.apache.pulsar.proxy.server.ProxyKeyStoreTlsTestWithoutAuth](#r0s145)|3 :white_check_mark:|||7s|
+|[org.apache.pulsar.proxy.server.ProxyLookupThrottlingTest](#r0s146)|1 :white_check_mark:|||3s|
+|[org.apache.pulsar.proxy.server.ProxyParserTest](#r0s147)|5 :white_check_mark:|||1s|
+|[org.apache.pulsar.proxy.server.ProxyRolesEnforcementTest](#r0s148)|1 :white_check_mark:|||10s|
+|[org.apache.pulsar.proxy.server.ProxyStatsTest](#r0s149)|3 :white_check_mark:|||533ms|
+|[org.apache.pulsar.proxy.server.ProxyTest](#r0s150)|6 :white_check_mark:|||3s|
+|[org.apache.pulsar.proxy.server.ProxyTlsTest](#r0s151)|2 :white_check_mark:|||414ms|
+|[org.apache.pulsar.proxy.server.ProxyTlsTestWithAuth](#r0s152)|1 :white_check_mark:|||4ms|
+|[org.apache.pulsar.proxy.server.ProxyWithAuthorizationNegTest](#r0s153)|1 :white_check_mark:|||2s|
+|[org.apache.pulsar.proxy.server.ProxyWithAuthorizationTest](#r0s154)|13 :white_check_mark:|||33s|
+|[org.apache.pulsar.proxy.server.ProxyWithoutServiceDiscoveryTest](#r0s155)|1 :white_check_mark:|||2s|
+|[org.apache.pulsar.proxy.server.SuperUserAuthedAdminProxyHandlerTest](#r0s156)|3 :white_check_mark:|||8s|
+|[org.apache.pulsar.proxy.server.UnauthedAdminProxyHandlerTest](#r0s157)|2 :white_check_mark:|||114ms|
+|[org.apache.pulsar.PulsarBrokerStarterTest](#r0s158)|9 :white_check_mark:|||591ms|
+|[org.apache.pulsar.schema.compatibility.SchemaCompatibilityCheckTest](#r0s159)|23 :white_check_mark:|||107s|
+|[org.apache.pulsar.schema.PartitionedTopicSchemaTest](#r0s160)|1 :white_check_mark:|||29s|
+|[org.apache.pulsar.schema.SchemaTest](#r0s161)|3 :white_check_mark:|||31s|
+|[org.apache.pulsar.stats.client.PulsarBrokerStatsClientTest](#r0s162)|2 :white_check_mark:|||41s|
+|[org.apache.pulsar.tests.EnumValuesDataProviderTest](#r0s163)|6 :white_check_mark:|||23ms|
+|[org.apache.pulsar.tests.TestRetrySupportBeforeMethodRetryTest](#r0s164)|1 :white_check_mark:||4 :warning:|36ms|
+|[org.apache.pulsar.tests.TestRetrySupportRetryTest](#r0s165)|1 :white_check_mark:||4 :warning:|27ms|
+|[org.apache.pulsar.tests.TestRetrySupportSuccessTest](#r0s166)|3 :white_check_mark:|||1ms|
+|[org.apache.pulsar.tests.ThreadDumpUtilTest](#r0s167)|2 :white_check_mark:|||17ms|
+|[org.apache.pulsar.utils.SimpleTextOutputStreamTest](#r0s168)|4 :white_check_mark:|||50ms|
+|[org.apache.pulsar.utils.StatsOutputStreamTest](#r0s169)|6 :white_check_mark:|||59ms|
+|[org.apache.pulsar.websocket.proxy.ProxyAuthenticationTest](#r0s170)|4 :white_check_mark:|||29s|
+|[org.apache.pulsar.websocket.proxy.ProxyAuthorizationTest](#r0s171)|1 :white_check_mark:|||1s|
+|[org.apache.pulsar.websocket.proxy.ProxyConfigurationTest](#r0s172)|2 :white_check_mark:|||9s|
+|[org.apache.pulsar.websocket.proxy.ProxyPublishConsumeTlsTest](#r0s173)|1 :white_check_mark:|||11s|
+|[org.apache.pulsar.websocket.proxy.ProxyPublishConsumeWithoutZKTest](#r0s174)|1 :white_check_mark:|||7s|
+|[org.apache.pulsar.websocket.proxy.v1.V1_ProxyAuthenticationTest](#r0s175)|4 :white_check_mark:|||30s|
 ### :x: <a id="user-content-r0s0" href="#r0s0">org.apache.pulsar.AddMissingPatchVersionTest</a>
 ```
 :warning: testVersionStrings

--- a/__tests__/__outputs__/silent-notes-test-results.md
+++ b/__tests__/__outputs__/silent-notes-test-results.md
@@ -3,24 +3,24 @@
  
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|VanillaCloudStorageClientTest|67:white_check_mark:||12:warning:|1s|
+|VanillaCloudStorageClientTest|67 :white_check_mark:||12 :warning:|1s|
 ## :white_check_mark: <a id="user-content-r0" href="#r0">VanillaCloudStorageClientTest</a>
 **79** tests were completed in **1s** with **67** passed, **0** failed and **12** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[VanillaCloudStorageClientTest.CloudStorageCredentialsTest](#r0s0)|6:white_check_mark:|||30ms|
-|[VanillaCloudStorageClientTest.CloudStorageProviders.DropboxCloudStorageClientTest](#r0s1)|2:white_check_mark:||3:warning:|101ms|
-|[VanillaCloudStorageClientTest.CloudStorageProviders.FtpCloudStorageClientTest](#r0s2)|4:white_check_mark:||3:warning:|166ms|
-|[VanillaCloudStorageClientTest.CloudStorageProviders.GmxCloudStorageClientTest](#r0s3)|2:white_check_mark:|||7ms|
-|[VanillaCloudStorageClientTest.CloudStorageProviders.GoogleCloudStorageClientTest](#r0s4)|1:white_check_mark:||3:warning:|40ms|
-|[VanillaCloudStorageClientTest.CloudStorageProviders.OnedriveCloudStorageClientTest](#r0s5)|1:white_check_mark:||3:warning:|15ms|
-|[VanillaCloudStorageClientTest.CloudStorageProviders.WebdavCloudStorageClientTest](#r0s6)|5:white_check_mark:|||16ms|
-|[VanillaCloudStorageClientTest.CloudStorageTokenTest](#r0s7)|9:white_check_mark:|||0ms|
-|[VanillaCloudStorageClientTest.OAuth2.AuthorizationResponseErrorTest](#r0s8)|3:white_check_mark:|||3ms|
-|[VanillaCloudStorageClientTest.OAuth2.OAuth2UtilsTest](#r0s9)|9:white_check_mark:|||12ms|
-|[VanillaCloudStorageClientTest.OAuth2CloudStorageClientTest](#r0s10)|5:white_check_mark:|||13ms|
-|[VanillaCloudStorageClientTest.SecureStringExtensionsTest](#r0s11)|7:white_check_mark:|||0ms|
-|[VanillaCloudStorageClientTest.SerializeableCloudStorageCredentialsTest](#r0s12)|13:white_check_mark:|||43ms|
+|[VanillaCloudStorageClientTest.CloudStorageCredentialsTest](#r0s0)|6 :white_check_mark:|||30ms|
+|[VanillaCloudStorageClientTest.CloudStorageProviders.DropboxCloudStorageClientTest](#r0s1)|2 :white_check_mark:||3 :warning:|101ms|
+|[VanillaCloudStorageClientTest.CloudStorageProviders.FtpCloudStorageClientTest](#r0s2)|4 :white_check_mark:||3 :warning:|166ms|
+|[VanillaCloudStorageClientTest.CloudStorageProviders.GmxCloudStorageClientTest](#r0s3)|2 :white_check_mark:|||7ms|
+|[VanillaCloudStorageClientTest.CloudStorageProviders.GoogleCloudStorageClientTest](#r0s4)|1 :white_check_mark:||3 :warning:|40ms|
+|[VanillaCloudStorageClientTest.CloudStorageProviders.OnedriveCloudStorageClientTest](#r0s5)|1 :white_check_mark:||3 :warning:|15ms|
+|[VanillaCloudStorageClientTest.CloudStorageProviders.WebdavCloudStorageClientTest](#r0s6)|5 :white_check_mark:|||16ms|
+|[VanillaCloudStorageClientTest.CloudStorageTokenTest](#r0s7)|9 :white_check_mark:|||0ms|
+|[VanillaCloudStorageClientTest.OAuth2.AuthorizationResponseErrorTest](#r0s8)|3 :white_check_mark:|||3ms|
+|[VanillaCloudStorageClientTest.OAuth2.OAuth2UtilsTest](#r0s9)|9 :white_check_mark:|||12ms|
+|[VanillaCloudStorageClientTest.OAuth2CloudStorageClientTest](#r0s10)|5 :white_check_mark:|||13ms|
+|[VanillaCloudStorageClientTest.SecureStringExtensionsTest](#r0s11)|7 :white_check_mark:|||0ms|
+|[VanillaCloudStorageClientTest.SerializeableCloudStorageCredentialsTest](#r0s12)|13 :white_check_mark:|||43ms|
 ### :white_check_mark: <a id="user-content-r0s0" href="#r0s0">VanillaCloudStorageClientTest.CloudStorageCredentialsTest</a>
 ```
 :white_check_mark: AreEqualWorksWithDifferentPassword

--- a/__tests__/__outputs__/swift-xunit.md
+++ b/__tests__/__outputs__/swift-xunit.md
@@ -1,12 +1,12 @@
 ![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|fixtures/swift-xunit.xml|2:white_check_mark:|1:x:||220ms|
+|fixtures/swift-xunit.xml|2 :white_check_mark:|1 :x:||220ms|
 ## :x: <a id="user-content-r0" href="#r0">fixtures/swift-xunit.xml</a>
 **3** tests were completed in **220ms** with **2** passed, **1** failed and **0** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[TestResults](#r0s0)|2:white_check_mark:|1:x:||220ms|
+|[TestResults](#r0s0)|2 :white_check_mark:|1 :x:||220ms|
 ### :x: <a id="user-content-r0s0" href="#r0s0">TestResults</a>
 ```
 AcmeLibTests.AcmeLibTests

--- a/dist/index.js
+++ b/dist/index.js
@@ -1566,7 +1566,9 @@ const node_utils_1 = __nccwpck_require__(5824);
 const parse_utils_1 = __nccwpck_require__(7811);
 const slugger_1 = __nccwpck_require__(3328);
 const MAX_REPORT_LENGTH = 65535;
-const MAX_ACTIONS_SUMMARY_LENGTH = 131072; // 1048576 soon
+// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
+// 1MiB content limit
+const MAX_ACTIONS_SUMMARY_LENGTH = 1048576;
 const defaultOptions = {
     listSuites: 'all',
     listTests: 'all',

--- a/dist/index.js
+++ b/dist/index.js
@@ -1687,9 +1687,9 @@ function getTestRunsReport(testRuns, options) {
             .map(tr => {
             const time = (0, markdown_utils_1.formatTime)(tr.time);
             const name = tr.path;
-            const passed = tr.passed > 0 ? `${tr.passed}${markdown_utils_1.Icon.success}` : '';
-            const failed = tr.failed > 0 ? `${tr.failed}${markdown_utils_1.Icon.fail}` : '';
-            const skipped = tr.skipped > 0 ? `${tr.skipped}${markdown_utils_1.Icon.skip}` : '';
+            const passed = tr.passed > 0 ? `${tr.passed} ${markdown_utils_1.Icon.success}` : '';
+            const failed = tr.failed > 0 ? `${tr.failed} ${markdown_utils_1.Icon.fail}` : '';
+            const skipped = tr.skipped > 0 ? `${tr.skipped} ${markdown_utils_1.Icon.skip}` : '';
             return [name, passed, failed, skipped, time];
         });
         const resultsTable = (0, markdown_utils_1.table)(['Report', 'Passed', 'Failed', 'Skipped', 'Time'], [markdown_utils_1.Align.Left, markdown_utils_1.Align.Right, markdown_utils_1.Align.Right, markdown_utils_1.Align.Right, markdown_utils_1.Align.Right], ...tableData);
@@ -1724,9 +1724,9 @@ function getSuitesReport(tr, runIndex, options) {
                 const skipLink = options.listTests === 'none' || (options.listTests === 'failed' && s.result !== 'failed');
                 const tsAddr = options.baseUrl + makeSuiteSlug(runIndex, suiteIndex).link;
                 const tsNameLink = skipLink ? tsName : (0, markdown_utils_1.link)(tsName, tsAddr);
-                const passed = s.passed > 0 ? `${s.passed}${markdown_utils_1.Icon.success}` : '';
-                const failed = s.failed > 0 ? `${s.failed}${markdown_utils_1.Icon.fail}` : '';
-                const skipped = s.skipped > 0 ? `${s.skipped}${markdown_utils_1.Icon.skip}` : '';
+                const passed = s.passed > 0 ? `${s.passed} ${markdown_utils_1.Icon.success}` : '';
+                const failed = s.failed > 0 ? `${s.failed} ${markdown_utils_1.Icon.fail}` : '';
+                const skipped = s.skipped > 0 ? `${s.skipped} ${markdown_utils_1.Icon.skip}` : '';
                 return [tsNameLink, passed, failed, skipped, tsTime];
             }));
             sections.push(suitesTable);

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -6,7 +6,9 @@ import {getFirstNonEmptyLine} from '../utils/parse-utils'
 import {slug} from '../utils/slugger'
 
 const MAX_REPORT_LENGTH = 65535
-const MAX_ACTIONS_SUMMARY_LENGTH = 131072 // 1048576 soon
+// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#step-isolation-and-limits
+// 1MiB content limit
+const MAX_ACTIONS_SUMMARY_LENGTH = 1048576
 
 export interface ReportOptions {
   listSuites: 'all' | 'failed' | 'none'

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -157,9 +157,9 @@ function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): s
       .map(tr => {
         const time = formatTime(tr.time)
         const name = tr.path
-        const passed = tr.passed > 0 ? `${tr.passed}${Icon.success}` : ''
-        const failed = tr.failed > 0 ? `${tr.failed}${Icon.fail}` : ''
-        const skipped = tr.skipped > 0 ? `${tr.skipped}${Icon.skip}` : ''
+        const passed = tr.passed > 0 ? `${tr.passed} ${Icon.success}` : ''
+        const failed = tr.failed > 0 ? `${tr.failed} ${Icon.fail}` : ''
+        const skipped = tr.skipped > 0 ? `${tr.skipped} ${Icon.skip}` : ''
         return [name, passed, failed, skipped, time]
       })
 
@@ -209,9 +209,9 @@ function getSuitesReport(tr: TestRunResult, runIndex: number, options: ReportOpt
           const skipLink = options.listTests === 'none' || (options.listTests === 'failed' && s.result !== 'failed')
           const tsAddr = options.baseUrl + makeSuiteSlug(runIndex, suiteIndex).link
           const tsNameLink = skipLink ? tsName : link(tsName, tsAddr)
-          const passed = s.passed > 0 ? `${s.passed}${Icon.success}` : ''
-          const failed = s.failed > 0 ? `${s.failed}${Icon.fail}` : ''
-          const skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : ''
+          const passed = s.passed > 0 ? `${s.passed} ${Icon.success}` : ''
+          const failed = s.failed > 0 ? `${s.failed} ${Icon.fail}` : ''
+          const skipped = s.skipped > 0 ? `${s.skipped} ${Icon.skip}` : ''
           return [tsNameLink, passed, failed, skipped, tsTime]
         })
       )


### PR DESCRIPTION
This is a follow-up PR to https://github.com/dorny/test-reporter/pull/383 to add:

- Extension to the content length of Actions Summary markdown - now up to 1Mbit
- Add space between number and emoji as the current format won't render properly in GitHub, as demonstrated below:

`1:white_check_mark:` is rendered as:
> 1:white_check_mark:

`1 :white_check_mark:` is rendered as:
> 1 :white_check_mark: